### PR TITLE
add PlainURL option for HttpRequest.

### DIFF
--- a/src/main/java/com/mashape/unirest/request/HttpRequest.java
+++ b/src/main/java/com/mashape/unirest/request/HttpRequest.java
@@ -100,4 +100,12 @@ public class HttpRequest extends BaseRequest {
 		return body;
 	}
 	
+	public HttpRequest plainURL(String plainURL) {
+		if(plainURL == null) {
+			throw new RuntimeException(new Exception("Plain URL == null"));
+		}
+		this.url = plainURL;
+		return this;
+	}
+	
 }


### PR DESCRIPTION
In case no need to encode the URL and it should be processed by developer manually.

It's very important for some APIs, i.e. 
There is a '/' in the path as a param, the server is expected: "http://www.xxx.com/api/%2f/user"
but it will not be encoded by java.net.URL if you just put "http://www.xxx.com/api///user",
and it will be double encoded as "http://www.xxx.com/api/%252F/user" if you put "http://www.xxx.com/api/%2F/user".
