### PR TITLE
Add method to set the default HttpClient

### DIFF
--- a/src/main/java/com/mashape/unirest/http/utils/ClientFactory.java
+++ b/src/main/java/com/mashape/unirest/http/utils/ClientFactory.java
@@ -29,5 +29,9 @@ public class ClientFactory {
 		}
 		return asyncHttpClient;
 	}
+
+	public static void setHttpClient(HttpClient httpClient) {
+		ClientFactory.httpClient = httpClient;
+	}
 	
 }


### PR DESCRIPTION
This is usefull to create Pooling Clients like:

PoolingClientConnectionManager conMan = new PoolingClientConnectionManager(SchemeRegistryFactory.createDefault());
conMan.setMaxTotal(200);
conMan.setDefaultMaxPerRoute(200);
HttpClient client = new DefaultHttpClient(conMan);
ClientFactory.setHttpClient(client);
