### PR TITLE
Fix a international Character encoding bug.

### DIFF
--- a/src/main/java/com/mashape/unirest/http/HttpResponse.java
+++ b/src/main/java/com/mashape/unirest/http/HttpResponse.java
@@ -65,6 +65,10 @@ public class HttpResponse<T> {
 			list.add(header.getValue());
 			headers.put(headerName, list);
 		}
+		String contentType=headers.get("content-type").toString();
+		if((contentType!=null)&&(contentType.contains("charset=")))
+			charSet=contentType.substring(contentType.indexOf("charset=")+8,contentType.length()-1).toLowerCase();
+		else charSet="utf-8";
 		this.code = response.getStatusLine().getStatusCode();
 		
 		if (responseEntity != null) {
@@ -83,10 +87,12 @@ public class HttpResponse<T> {
 				this.rawBody = inputStream;
 
 				if (JsonNode.class.equals(responseClass)) {
-					String jsonString =EntityUtils.toString(responseEntity).trim();
+					//String jsonString =EntityUtils.toString( response.getEntity()).trim();
+					String jsonString =new String(rawBody,charSet).trim();
 					this.body = (T) new JsonNode(jsonString);
 				} else if (String.class.equals(responseClass)) {
-					this.body= (T) EntityUtils.toString(responseEntity);	
+					//this.body= (T) EntityUtils.toString( response.getEntity());	
+					this.body=(T) new String(rawBody,charSet);
 				} else if (InputStream.class.equals(responseClass)) {
 					this.body = (T) this.rawBody;
 				} else {


### PR DESCRIPTION
HttpClient4 -Entity care Character/UTF-8
but InputStream not(HttpResponse.java)
使用流时要国际化字符集,注意转码
