### PR TITLE
Add an upload progress listener

### DIFF
--- a/src/main/java/com/mashape/unirest/http/async/AbstractCallback.java
+++ b/src/main/java/com/mashape/unirest/http/async/AbstractCallback.java
@@ -1,0 +1,10 @@
+package com.mashape.unirest.http.async;
+
+public abstract class AbstractCallback<T> implements Callback<T> {
+
+	@Override
+	public void uploadProgress(long bytesSent, long totalLength) {
+		// Stub method
+	}
+
+}

--- a/src/main/java/com/mashape/unirest/http/async/Callback.java
+++ b/src/main/java/com/mashape/unirest/http/async/Callback.java
@@ -35,4 +35,7 @@ public interface Callback<T> {
 	void failed(UnirestException e);
 	
 	void cancelled();
+	
+	void uploadProgress(long bytesSent, long totalLength);
+	
 }

--- a/src/main/java/com/mashape/unirest/request/progress/ProgressListener.java
+++ b/src/main/java/com/mashape/unirest/request/progress/ProgressListener.java
@@ -1,0 +1,7 @@
+package com.mashape.unirest.request.progress;
+
+public interface ProgressListener {
+	
+	public void progress(long deltaBytes, long totalLength);
+	
+}

--- a/src/main/java/com/mashape/unirest/request/progress/ProgressReportingOutputStream.java
+++ b/src/main/java/com/mashape/unirest/request/progress/ProgressReportingOutputStream.java
@@ -1,0 +1,57 @@
+package com.mashape.unirest.request.progress;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class ProgressReportingOutputStream extends OutputStream {
+
+	private final OutputStream out;
+	private volatile long written = 0;
+	private long length;
+	private ProgressListener listener;
+	
+	public ProgressReportingOutputStream(OutputStream out, long length,
+			ProgressListener listener) {
+		this.out = out;
+		this.length = length;
+		this.listener = listener;
+	}
+
+	@Override
+	public void write(int b) throws IOException {
+		out.write(b);
+		written ++;
+		if (listener != null) {
+			listener.progress(1, length);
+		}
+	}
+
+	@Override
+	public void write(byte[] b) throws IOException {
+		out.write(b);
+		written += b.length;
+		if (listener != null) {
+			listener.progress(b.length, length);
+		}
+	}
+
+	@Override
+	public void write(byte[] b, int off, int len) throws IOException {
+		out.write(b, off, len);
+		written += len;
+		if (listener != null) {
+			listener.progress(len, length);
+		}
+	}
+
+	@Override
+	public void flush() throws IOException {
+		out.flush();
+	}
+
+	@Override
+	public void close() throws IOException {
+		out.close();
+	}
+
+}

--- a/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
+++ b/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
@@ -27,6 +27,7 @@ package com.mashape.unirest.test.http;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -56,11 +57,13 @@ public class UnirestTest {
 
 	private CountDownLatch lock;
 	private boolean status;
+	private long uploadSize, uploadBytesLeft;
 	
 	@Before
 	public void setUp() {
 		lock = new CountDownLatch(1);
 		status = false;
+		uploadSize = uploadBytesLeft = -1;
 	}
 	
 	private String findAvailableIpAddress() throws UnknownHostException, IOException {
@@ -202,10 +205,23 @@ public class UnirestTest {
 			public void cancelled() {
 				fail();
 			}
+
+			@Override
+			public void uploadProgress(long bytesSent, long totalLength) {
+				assertNotEquals(0, totalLength);
+				if (uploadSize == -1) {
+					uploadSize = totalLength;
+				} else {
+					assertEquals(uploadSize, totalLength);
+				}
+				uploadBytesLeft = totalLength - bytesSent;
+			}
 		});
 		
 		lock.await(10, TimeUnit.SECONDS);
 		assertTrue(status);
+		assertEquals(0, uploadBytesLeft);
+		assertNotEquals(0, uploadSize);
 	}
 	
 	@Test
@@ -264,11 +280,23 @@ public class UnirestTest {
 			public void cancelled() {
 				fail();
 			}
-			
+
+			@Override
+			public void uploadProgress(long bytesSent, long totalLength) {
+				assertNotEquals(0, totalLength);
+				if (uploadSize == -1) {
+					uploadSize = totalLength;
+				} else {
+					assertEquals(uploadSize, totalLength);
+				}
+				uploadBytesLeft = totalLength - bytesSent;
+			}
 		});
 		
 		lock.await(10, TimeUnit.SECONDS);
 		assertTrue(status);
+		assertEquals(0, uploadBytesLeft);
+		assertNotEquals(0, uploadSize);
 	}
 	
 	@Test


### PR DESCRIPTION
This relates to gh-26.

It sounds odd, but I couldn't work out how to add a download progress listener. The FutureCallback interface doesn't expose any way to get at the progress, but it might be possible to do by implementing HttpAsyncRequestProducer and HttpAsyncResponseConsumer and passing them into CloseableHttpAsyncClient's method execute(HttpAsyncRequestProducer, HttpAsyncResponseConsumer<T>, FutureCallback<T> callback)

Existing uses of Callback will need to implement the new method or extend AbstractCallback instead. Is that acceptable? It makes the interface to the library technically non-backwards-compatible.
