### PR TITLE
Change ContentType parameter for StringBody

### DIFF
--- a/src/main/java/com/mashape/unirest/request/body/MultipartBody.java
+++ b/src/main/java/com/mashape/unirest/request/body/MultipartBody.java
@@ -88,7 +88,7 @@ public class MultipartBody extends BaseRequest implements Body {
 				if (value instanceof File) {
 					builder.addPart(key, new FileBody((File) value));
 				} else {
-					builder.addPart(key, new StringBody(value.toString(), ContentType.APPLICATION_FORM_URLENCODED));
+					builder.addPart(key, new StringBody(value.toString(), ContentType.create("text/plain", UTF_8)));
 				}
 			}
 			return builder.build();

--- a/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
+++ b/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
@@ -179,6 +179,7 @@ public class UnirestTest {
 		 .header("accept", "application/json")
 		 .field("param1", "value1")
 		 .field("param2","bye")
+		 .field("param3","こんにちは")
 		 .asJsonAsync(new Callback<JsonNode>() {
 			
 			public void failed(UnirestException e) {
@@ -200,6 +201,7 @@ public class UnirestTest {
 				
 				assertEquals("value1", json.getObject().getJSONObject("form").getString("param1"));
 				assertEquals("bye", json.getObject().getJSONObject("form").getString("param2"));
+				assertEquals("こんにちは", json.getObject().getJSONObject("form").getString("param3"));
 				
 				status = true;
 				lock.countDown();
@@ -219,6 +221,7 @@ public class UnirestTest {
 		HttpResponse<JsonNode> jsonResponse =
 				Unirest.post("http://httpbin.org/post")
 				.field("name", "Mark")
+				.field("greeting", "こんにちは")
 				.field("file", new File(getClass().getResource("/test").toURI())).asJson();
 		assertTrue(jsonResponse.getHeaders().size() > 0);
 		assertTrue(jsonResponse.getBody().toString().length() > 0);
@@ -235,6 +238,7 @@ public class UnirestTest {
 		
 		assertEquals("This \nis \na \ntest \nfile", json.getObject().getJSONObject("files").getString("file"));
 		assertEquals("Mark", json.getObject().getJSONObject("form").getString("name"));
+		assertEquals("こんにちは", json.getObject().getJSONObject("form").getString("greeting"));
 	}
 	
 	@Test


### PR DESCRIPTION
Change ContentType parameter of the StringBody in the MultipartBody class.
Non-ASCII characters are broken when the body has a File instance.
It is probably best that the ContentType is "plain/text" and "utf-8" by default.
