### PR TITLE
Set background threads to daemon mode, meaning they no longer prevent JVM shutdown

### DIFF
--- a/src/main/java/com/mashape/unirest/http/async/utils/AsyncIdleConnectionMonitorThread.java
+++ b/src/main/java/com/mashape/unirest/http/async/utils/AsyncIdleConnectionMonitorThread.java
@@ -11,6 +11,7 @@ public class AsyncIdleConnectionMonitorThread extends Thread {
     
     public AsyncIdleConnectionMonitorThread(PoolingNHttpClientConnectionManager connMgr) {
         super();
+        super.setDaemon(true);
         this.connMgr = connMgr;
     }
 

--- a/src/main/java/com/mashape/unirest/http/utils/SyncIdleConnectionMonitorThread.java
+++ b/src/main/java/com/mashape/unirest/http/utils/SyncIdleConnectionMonitorThread.java
@@ -11,6 +11,7 @@ public class SyncIdleConnectionMonitorThread extends Thread {
     
     public SyncIdleConnectionMonitorThread(HttpClientConnectionManager connMgr) {
         super();
+        super.setDaemon(true);        
         this.connMgr = connMgr;
     }
 


### PR DESCRIPTION
If you set the background threads to daemon mode, they won't prevent the JVM from exiting.  The modifications in this pull request still allow you to explicitly call Unirest.shutdown(), but you are no longer required to do so in order to exit.
