### PR TITLE
allow setDefaultHeaders to override User-Agent

### DIFF
--- a/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
+++ b/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
@@ -150,13 +150,6 @@ public class HttpClientHelper {
 
 	private static HttpRequestBase prepareRequest(HttpRequest request, boolean async) {
 
-		if (!request.getHeaders().containsKey(USER_AGENT_HEADER)) {
-			request.header(USER_AGENT_HEADER, USER_AGENT);
-		}
-		if (!request.getHeaders().containsKey(ACCEPT_ENCODING_HEADER)) { 
-			request.header(ACCEPT_ENCODING_HEADER, "gzip");
-		}
-
 		Object defaultHeaders = Options.getOption(Option.DEFAULT_HEADERS);
 		if (defaultHeaders != null) {
 			@SuppressWarnings("unchecked")
@@ -165,7 +158,14 @@ public class HttpClientHelper {
 				request.header(entry.getKey(), entry.getValue());
 			}
 		}
-		
+
+		if (!request.getHeaders().containsKey(USER_AGENT_HEADER)) {
+			request.header(USER_AGENT_HEADER, USER_AGENT);
+		}
+		if (!request.getHeaders().containsKey(ACCEPT_ENCODING_HEADER)) {
+			request.header(ACCEPT_ENCODING_HEADER, "gzip");
+		}
+
 		HttpRequestBase reqObj = null;
 
 		String urlToRequest = null;

--- a/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
+++ b/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
@@ -340,7 +340,8 @@ public class UnirestTest {
 	@Test
 	public void testDefaultHeaders() throws UnirestException, JSONException {
 		Unirest.setDefaultHeader("X-Custom-Header", "hello");
-		
+		Unirest.setDefaultHeader("user-agent", "foobar");
+
 		HttpResponse<JsonNode> jsonResponse =
 				Unirest.get("http://httpbin.org/headers").asJson();
 		assertTrue(jsonResponse.getHeaders().size() > 0);
@@ -352,7 +353,9 @@ public class UnirestTest {
 		assertFalse(json.isArray());
 		assertTrue(jsonResponse.getBody().getObject().getJSONObject("headers").has("X-Custom-Header"));
 		assertEquals("hello", json.getObject().getJSONObject("headers").getString("X-Custom-Header"));
-		
+		assertTrue(jsonResponse.getBody().getObject().getJSONObject("headers").has("User-Agent"));
+		assertEquals("foobar", json.getObject().getJSONObject("headers").getString("User-Agent"));
+
 		jsonResponse = Unirest.get("http://httpbin.org/headers").asJson();
 		assertTrue(jsonResponse.getBody().getObject().getJSONObject("headers").has("X-Custom-Header"));
 		assertEquals("hello", jsonResponse.getBody().getObject().getJSONObject("headers").getString("X-Custom-Header"));


### PR DESCRIPTION
The User-Agent header is one of the prime candidates of headers to be
customized by default for every request, so it makes sense to allow
customizing it via setDefaultHeaders.

Before this commit, request specific headers would be set first and
the default user agent would then be added in addition to the request
specific header
