### PR TITLE
asString method specified character set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,3 @@ jdk:
 
 os:
   - linux
-  - osx

--- a/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
+++ b/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
@@ -90,6 +90,10 @@ public class HttpClientHelper {
 	}
 
 	public static <T> Future<HttpResponse<T>> requestAsync(HttpRequest request, final Class<T> responseClass, Callback<T> callback) {
+		return requestAsync(request, "UTF-8", responseClass, callback);
+	}
+	
+	public static <T> Future<HttpResponse<T>> requestAsync(HttpRequest request, final String charset, final Class<T> responseClass, Callback<T> callback) {
 		HttpUriRequest requestObj = prepareRequest(request, true);
 
 		CloseableHttpAsyncClient asyncHttpClient = ClientFactory.getAsyncHttpClient();
@@ -117,7 +121,7 @@ public class HttpClientHelper {
 
 			public HttpResponse<T> get() throws InterruptedException, ExecutionException {
 				org.apache.http.HttpResponse httpResponse = future.get();
-				return new HttpResponse<T>(httpResponse, responseClass);
+				return new HttpResponse<T>(httpResponse, charset, responseClass);
 			}
 
 			public HttpResponse<T> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
@@ -128,6 +132,10 @@ public class HttpClientHelper {
 	}
 
 	public static <T> HttpResponse<T> request(HttpRequest request, Class<T> responseClass) throws UnirestException {
+		return request(request, "UTF-8", responseClass);
+	}
+	
+	public static <T> HttpResponse<T> request(HttpRequest request, String charset, Class<T> responseClass) throws UnirestException {
 		HttpRequestBase requestObj = prepareRequest(request, false);
 		HttpClient client = ClientFactory.getHttpClient(); // The
 															// DefaultHttpClient
@@ -136,7 +144,7 @@ public class HttpClientHelper {
 		org.apache.http.HttpResponse response;
 		try {
 			response = client.execute(requestObj);
-			HttpResponse<T> httpResponse = new HttpResponse<T>(response, responseClass);
+			HttpResponse<T> httpResponse = new HttpResponse<T>(response, charset, responseClass);
 			requestObj.releaseConnection();
 			return httpResponse;
 		} catch (Exception e) {

--- a/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
+++ b/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
@@ -247,6 +248,7 @@ public class HttpClientHelper {
 			}
 		}
 
+		reqObj.setConfig(RequestConfig.custom().setRedirectsEnabled(request.isRedirectsEnabled()).build());
 		return reqObj;
 	}
 

--- a/src/main/java/com/mashape/unirest/http/HttpResponse.java
+++ b/src/main/java/com/mashape/unirest/http/HttpResponse.java
@@ -47,9 +47,13 @@ public class HttpResponse<T> {
 	private Headers headers = new Headers();
 	private InputStream rawBody;
 	private T body;
+	
+	public HttpResponse(org.apache.http.HttpResponse response, Class<T> responseClass) {
+		this(response, "UTF-8", responseClass);
+	}
 
 	@SuppressWarnings("unchecked")
-	public HttpResponse(org.apache.http.HttpResponse response, Class<T> responseClass) {
+	public HttpResponse(org.apache.http.HttpResponse response, String charset, Class<T> responseClass) {
 		HttpEntity responseEntity = response.getEntity();
 		ObjectMapper objectMapper = (ObjectMapper) Options.getOption(Option.OBJECT_MAPPER);
 
@@ -67,8 +71,6 @@ public class HttpResponse<T> {
 		this.statusText = statusLine.getReasonPhrase();
 
 		if (responseEntity != null) {
-			String charset = "UTF-8";
-
 			Header contentType = responseEntity.getContentType();
 			if (contentType != null) {
 				String responseCharset = ResponseUtils.getCharsetFromContentType(contentType.getValue());

--- a/src/main/java/com/mashape/unirest/request/BaseRequest.java
+++ b/src/main/java/com/mashape/unirest/request/BaseRequest.java
@@ -52,16 +52,28 @@ public abstract class BaseRequest {
 		super();
 	}
 
+	public HttpResponse<String> asString(String charset) throws UnirestException {
+		return HttpClientHelper.request(httpRequest, charset, String.class);
+	}
+	
 	public HttpResponse<String> asString() throws UnirestException {
-		return HttpClientHelper.request(httpRequest, String.class);
+		return asString(UTF_8);
 	}
 
+	public Future<HttpResponse<String>> asStringAsync(String charset) {
+		return HttpClientHelper.requestAsync(httpRequest, charset, String.class, null);
+	}
+	
 	public Future<HttpResponse<String>> asStringAsync() {
-		return HttpClientHelper.requestAsync(httpRequest, String.class, null);
+		return asStringAsync(UTF_8);
 	}
 
+	public Future<HttpResponse<String>> asStringAsync(String charset, Callback<String> callback) {
+		return HttpClientHelper.requestAsync(httpRequest, charset, String.class, callback);
+	}
+	
 	public Future<HttpResponse<String>> asStringAsync(Callback<String> callback) {
-		return HttpClientHelper.requestAsync(httpRequest, String.class, callback);
+		return asStringAsync(UTF_8, callback);
 	}
 
 	public HttpResponse<JsonNode> asJson() throws UnirestException {

--- a/src/main/java/com/mashape/unirest/request/HttpRequest.java
+++ b/src/main/java/com/mashape/unirest/request/HttpRequest.java
@@ -48,13 +48,20 @@ public class HttpRequest extends BaseRequest {
 	protected String url;
 	Map<String, List<String>> headers = new TreeMap<String, List<String>>(String.CASE_INSENSITIVE_ORDER);
 	protected Body body;
+	protected boolean redirectsEnabled;
 
 	public HttpRequest(HttpMethod method, String url) {
 		this.httpMethod = method;
 		this.url = url;
+		this.redirectsEnabled = true;
 		super.httpRequest = this;
 	}
 
+	public HttpRequest redirectsEnabled(boolean redirectsEnabled) {
+		this.redirectsEnabled = redirectsEnabled;
+		return this;
+	}
+	
 	public HttpRequest routeParam(String name, String value) {
 		Matcher matcher = Pattern.compile("\\{" + name + "\\}").matcher(url);
 		int count = 0;
@@ -144,6 +151,10 @@ public class HttpRequest extends BaseRequest {
 
 	public Body getBody() {
 		return body;
+	}
+
+	public boolean isRedirectsEnabled() {
+		return redirectsEnabled;
 	}
 
 }


### PR DESCRIPTION
Sometimes the response conten-type in the standard HTTP and no character set information, is currently the default UTF-8 character set, hoping to provide asString ("GBK") similar to the API
