### PR TITLE
fix for #141 and #137

### DIFF
--- a/src/main/java/com/mashape/unirest/request/HttpRequest.java
+++ b/src/main/java/com/mashape/unirest/request/HttpRequest.java
@@ -64,7 +64,11 @@ public class HttpRequest extends BaseRequest {
 		if (count == 0) {
 			throw new RuntimeException("Can't find route parameter name \"" + name + "\"");
 		}
-		this.url = url.replaceAll("\\{" + name + "\\}", URLParamEncoder.encode(value));
+		try {
+			this.url = url.replaceAll("\\{" + name + "\\}", URLEncoder.encode(value, "UTF-8"));
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
+		}
 		return this;
 	}
 


### PR DESCRIPTION
I throw out the call to `URLParamEncoder`and made the code consistent with how query parameters are encoded.
Now the encoding uses `URLEncoder.encode(value, "UTF-8")` just like the queryString method
