### PR TITLE
Defer body parsing until getBody() is called.

### DIFF
--- a/src/main/java/com/mashape/unirest/http/BodyReader.java
+++ b/src/main/java/com/mashape/unirest/http/BodyReader.java
@@ -1,0 +1,5 @@
+package com.mashape.unirest.http;
+
+public interface BodyReader<T> {
+    T getBody();
+}

--- a/src/main/java/com/mashape/unirest/http/BodyReaders.java
+++ b/src/main/java/com/mashape/unirest/http/BodyReaders.java
@@ -1,0 +1,55 @@
+package com.mashape.unirest.http;
+
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+
+public class BodyReaders {
+    public static BodyReader<JsonNode> forJsonNode(final byte[] rawBody, final String charset) {
+        return new BodyReader<JsonNode>() {
+            public JsonNode getBody() {
+                try {
+                    String jsonString = new String(rawBody, charset).trim();
+                    return new JsonNode(jsonString);
+                } catch (UnsupportedEncodingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    public static BodyReader<String> forString(final byte[] rawBody, final String charset) {
+        return new BodyReader<String>() {
+            public String getBody() {
+                try {
+                    return new String(rawBody, charset);
+                } catch (UnsupportedEncodingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    public static BodyReader<InputStream> forInputStream(final InputStream rawBody) {
+        return new BodyReader<InputStream>() {
+            public InputStream getBody() {
+                return rawBody;
+            }
+        };
+    }
+
+    public static <T> BodyReader<T> forObjectMapper(final ObjectMapper objectMapper,
+                                                           final byte[] rawBody,
+                                                           final String charset,
+                                                           final Class<T> responseClass) {
+        return new BodyReader<T>() {
+            public T getBody() {
+                try {
+                    return objectMapper.readValue(new String(rawBody, charset), responseClass);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Me and my colleagues were running into problems when the HTTP call would fail because of invalid credentials. But instead of a useful error message we were getting a deserialisation error (we're using a Jackson ObjectMapper).

The call itself should not fail with a serialisation error when e.g. HTTP 401 Unauthorized is returned.
If we defer parsing the body until getBody() is called we are able to check other properties, e.g. return code, response headers, etc.

This is the quickest solution I could come up with. If you're generally willing to accept a PR along those lines, let me know what you think. Also, I wasn't able to get the tests running :-(
