### PR TITLE
use system properties by default

### DIFF
--- a/src/main/java/com/mashape/unirest/http/options/Options.java
+++ b/src/main/java/com/mashape/unirest/http/options/Options.java
@@ -74,7 +74,7 @@ public class Options {
 		syncConnectionManager.setDefaultMaxPerRoute((Integer) maxPerRoute);
 
 		// Create clients
-		setOption(Option.HTTPCLIENT, HttpClientBuilder.create().setDefaultRequestConfig(clientConfig).setConnectionManager(syncConnectionManager).build());
+		setOption(Option.HTTPCLIENT, HttpClientBuilder.create().setDefaultRequestConfig(clientConfig).setConnectionManager(syncConnectionManager).useSystemProperties().build());
 		SyncIdleConnectionMonitorThread syncIdleConnectionMonitorThread = new SyncIdleConnectionMonitorThread(syncConnectionManager);
 		setOption(Option.SYNC_MONITOR, syncIdleConnectionMonitorThread);
 		syncIdleConnectionMonitorThread.start();


### PR DESCRIPTION
The previous implementation completely ignores system properties like http.proxyHost and the like. http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/HttpClientBuilder.html (used by https://github.com/Mashape/unirest-java/blob/a31faff72bc7440a0293dd879dc5d3ef88c577c4/src/main/java/com/mashape/unirest/http/options/Options.java) provides the out of the box feature to consider these system properties.

This change simply uses said feature.
