### PR TITLE
Fix for OPTIONS requests in Unirest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.mashape.unirest</groupId>
 	<artifactId>unirest-java</artifactId>
 	<packaging>jar</packaging>
-	<version>1.4.10-SNAPSHOT</version>
+	<version>1.4.9-hotfix-options</version>
 	<name>unirest-java</name>
 	<description>Simplified, lightweight HTTP client library</description>
 	<url>http://unirest.io/</url>

--- a/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
+++ b/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
@@ -218,7 +218,7 @@ public class HttpClientHelper {
 		}
 
 		// Set body
-		if (!(request.getHttpMethod() == HttpMethod.GET || request.getHttpMethod() == HttpMethod.HEAD)) {
+		if (!(request.getHttpMethod() == HttpMethod.GET || request.getHttpMethod() == HttpMethod.HEAD || request.getHttpMethod() == HttpMethod.OPTIONS)) {
 			if (request.getBody() != null) {
 				HttpEntity entity = request.getBody().getEntity();
 				if (async) {


### PR DESCRIPTION
Unirest had a small bug regarding OPTIONS request which were stopping us of proxying requests to HATEOS / CORS using web applications.

It was a simple mistake in which OPTIONS was not considered a body-less http verb like GET and HEAD. Adding it to an if statement expression to ignore OPTIONS' body fixed. It was causing a runtime error due to casting the Options class to non-subclass Entity (which is the subclass of verbs with a body such as PUT and POST) : 

`((HttpEntityEnclosingRequestBase) reqObj).setEntity(entity);`


Did not add a unit test on it since they tests appear broken..? Loads fail in my machine at least...

I have tested in our testing environment and this simple fix seems to sufice. Everything else looks to be working correctly.

(please ignore the pom.xml version change in the pull request)

Kind Regards
Dan