### PR TITLE
fix tests broken by changes in httpbin. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
 					<source>1.5</source>
 					<target>1.5</target>
 					<encoding>UTF-8</encoding>
+					<testSource>1.5</testSource>
+					<testTarget>1.5</testTarget>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -137,6 +139,12 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sparkjava</groupId>
+			<artifactId>spark-core</artifactId>
+			<version>2.6.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/com/mashape/unirest/test/http/MockServer.java
+++ b/src/test/java/com/mashape/unirest/test/http/MockServer.java
@@ -1,0 +1,79 @@
+package com.mashape.unirest.test.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.entity.ContentType;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+import spark.Spark;
+
+import javax.servlet.MultipartConfigElement;
+import javax.servlet.http.Part;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+
+import static java.lang.System.getProperty;
+import static spark.Spark.*;
+
+public class MockServer {
+	private static final ObjectMapper om = new ObjectMapper();
+	public static int PORT = 4567;
+	public static String HOST = "http://localhost:" + PORT;
+
+	public static void start() {
+		port(PORT);
+		post("/post", ContentType.MULTIPART_FORM_DATA.getMimeType(), multipost);
+		get("/get", new Route() {
+			public Object handle(Request request, Response response) throws Exception {
+				return "Hi Momn";
+			}
+		});
+	}
+
+	private static Route multipost = new Route() {
+		public Object handle(Request req, Response res) throws Exception {
+			req.raw().setAttribute("org.eclipse.jetty.multipartConfig", new MultipartConfigElement(getProperty("java.io.tmpdir")));
+
+			ResponseBody body = new ResponseBody();
+			for (Part p : req.raw().getParts()) {
+				if (p.getContentType().equals(ContentType.APPLICATION_OCTET_STREAM.getMimeType())) {
+					buildFilePart(p, body);
+				} else {
+					buildFormPart(p, body);
+				}
+			}
+
+			return om.writeValueAsString(body);
+		}
+	};
+
+	private static void buildFormPart(Part p, ResponseBody body) throws IOException {
+		java.util.Scanner s = new Scanner(p.getInputStream()).useDelimiter("\\A");
+		String value = s.hasNext() ? s.next() : "";
+		body.form.put(p.getName(), value);
+	}
+
+	public static void buildFilePart(Part part, ResponseBody body){
+		body.files = new File();
+		body.files.fileName = part.getSubmittedFileName();
+		body.files.type = part.getContentType();
+		body.files.inputName = part.getName();
+	}
+
+	public static void shutdown() {
+		Spark.stop();
+	}
+
+	public static class ResponseBody {
+	 public File files;
+		public Map<String,String> form = new HashMap<String,String>();
+	}
+
+ public static class File {
+	 public String fileName;
+	 public String type;
+		public String inputName;
+	}
+}

--- a/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
+++ b/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
@@ -31,6 +31,7 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.http.options.Options;
 import com.mashape.unirest.request.GetRequest;
 import com.mashape.unirest.request.HttpRequest;
+import com.mashape.unirest.request.body.MultipartBody;
 import com.mashape.unirest.test.helper.GetResponse;
 import com.mashape.unirest.test.helper.JacksonObjectMapper;
 
@@ -41,8 +42,7 @@ import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.*;
 import java.net.InetAddress;
@@ -52,12 +52,23 @@ import java.util.Arrays;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.mashape.unirest.test.http.MockServer.HOST;
 import static org.junit.Assert.*;
 
 public class UnirestTest {
 
 	private CountDownLatch lock;
 	private boolean status;
+
+	@BeforeClass
+	public static void suiteSetUp(){
+		MockServer.start();
+	}
+
+	@AfterClass
+	public static void suiteTearDown(){
+		MockServer.shutdown();
+	}
 
 	@Before
 	public void setUp() {
@@ -297,7 +308,14 @@ public class UnirestTest {
 
 	@Test
 	public void testMultipartInputStreamContentType() throws JSONException, InterruptedException, ExecutionException, URISyntaxException, UnirestException, FileNotFoundException {
-		HttpResponse<JsonNode> jsonResponse = Unirest.post("http://httpbin.org/post").field("name", "Mark").field("file", new FileInputStream(new File(getClass().getResource("/image.jpg").toURI())), ContentType.APPLICATION_OCTET_STREAM, "image.jpg").asJson();
+		FileInputStream stream = new FileInputStream(new File(getClass().getResource("/image.jpg").toURI()));
+		MultipartBody request = Unirest.post(HOST + "/post")
+			.field("name", "Mark")
+			.field("file", stream, ContentType.APPLICATION_OCTET_STREAM, "image.jpg");
+
+		HttpResponse<JsonNode> jsonResponse = request
+			.asJson();
+
 		assertTrue(jsonResponse.getHeaders().size() > 0);
 		assertTrue(jsonResponse.getBody().toString().length() > 0);
 		assertFalse(jsonResponse.getRawBody() == null);
@@ -305,13 +323,14 @@ public class UnirestTest {
 
 		JsonNode json = jsonResponse.getBody();
 		assertFalse(json.isArray());
-		assertNotNull(json.getObject());
+		JSONObject object = json.getObject();
+		assertNotNull(object);
 		assertNotNull(json.getArray());
 		assertEquals(1, json.getArray().length());
 		assertNotNull(json.getArray().get(0));
-		assertNotNull(json.getObject().getJSONObject("files"));
+		assertNotNull(object.getJSONObject("files"));
 
-		assertTrue(json.getObject().getJSONObject("files").getString("file").contains("data:application/octet-stream"));
+		assertTrue(json.getObject().getJSONObject("files").getString("type").contains("application/octet-stream"));
 		assertEquals("Mark", json.getObject().getJSONObject("form").getString("name"));
 	}
 
@@ -592,7 +611,7 @@ public class UnirestTest {
 			newFixedThreadPool.execute(new Runnable() {
 				public void run() {
 					try {
-						Unirest.get("http://httpbin.org/get").queryString("index", counter.incrementAndGet()).asJson();
+						Unirest.get(HOST + "/get").queryString("index", counter.incrementAndGet()).asString();
 					} catch (UnirestException e) {
 						throw new RuntimeException(e);
 					}
@@ -733,9 +752,6 @@ public class UnirestTest {
 		assertEquals("John", request.getHeaders().get("NAme").get(1));
 		assertEquals("Marco", request.getHeaders().get("Name").get(0));
 		assertEquals("John", request.getHeaders().get("Name").get(1));
-
-		headers = request.asJson().getBody().getObject().getJSONObject("headers");
-		assertEquals("Marco,John", headers.get("Name"));
 	}
 
 	@Test
@@ -814,5 +830,11 @@ public class UnirestTest {
 		assertEquals("Only header \"Content-Type\" should exist", null, headers.getFirst("cOnTeNt-TyPe"));
 		assertEquals("Only header \"Content-Type\" should exist", null, headers.getFirst("content-type"));
 		assertEquals("Only header \"Content-Type\" should exist", "application/json", headers.getFirst("Content-Type"));
+	}
+
+	private static void debugApache() {
+		System.setProperty("org.apache.commons.logging.Log","org.apache.commons.logging.impl.SimpleLog");
+		System.setProperty("org.apache.commons.logging.simplelog.showdatetime", "true");
+		System.setProperty("org.apache.commons.logging.simplelog.log.org.apache.http.wire", "DEBUG");
 	}
 }


### PR DESCRIPTION
Eventually, IMHO, All tests should replace with the local spark server so that tests are reproducible and not dependent on an external system.

Specifically this deals with the following issues:

   1. httpbin doesn't seem to support multipart octet streams anymore. I believe the full file in one go would work but that's not what was being tested.
   1. httpbin also changed the way the headers are turned when there are multiples. I kept the unirest part of the test and removed checking httpbins body. We could do something better with Spark.
   1. The parallel test was flakey and would fail due to network slowness. Switching to spark fixes this. It was also rather rude to spam their server every time the test ran

On a side note. I would be interested in helping to maintain this codebase. I can commit to:

   1. Fixing the rests of the test
   1. Reviewing PRs
   1. Patching security holes (the version of HTTPClient is outdated and has security issues.
   1. Doing a few usability improvements.

This is a good project, I think it's certainly the easiest HTTP lib for Java and is great when you are on the receiving end of a changing API.



