### PR TITLE
Fix overriding of custom client in refresh() method

### DIFF
--- a/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
+++ b/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
@@ -130,9 +130,15 @@ public class HttpClientHelper {
 	public static <T> HttpResponse<T> request(HttpRequest request, Class<T> responseClass) throws UnirestException {
 		HttpRequestBase requestObj = prepareRequest(request, false);
 		HttpClient client = ClientFactory.getHttpClient(); // The
-															// DefaultHttpClient
-															// is thread-safe
+		return executeRequest(client, responseClass, requestObj);
+	}
 
+	public static <T> HttpResponse<T> request(HttpClient client, HttpRequest request, Class<T> responseClass) throws UnirestException {
+		HttpRequestBase requestObj = prepareRequest(request, false);
+		return executeRequest(client, responseClass, requestObj);
+	}
+
+	private static <T> HttpResponse<T> executeRequest(HttpClient client, Class<T> responseClass, HttpRequestBase requestObj) throws UnirestException {
 		org.apache.http.HttpResponse response;
 		try {
 			response = client.execute(requestObj);

--- a/src/main/java/com/mashape/unirest/request/BaseRequest.java
+++ b/src/main/java/com/mashape/unirest/request/BaseRequest.java
@@ -30,6 +30,7 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.async.Callback;
 import com.mashape.unirest.http.exceptions.UnirestException;
+import org.apache.http.client.HttpClient;
 
 import java.io.InputStream;
 import java.util.concurrent.Future;
@@ -56,6 +57,10 @@ public abstract class BaseRequest {
 		return HttpClientHelper.request(httpRequest, String.class);
 	}
 
+	public HttpResponse<String> asString(HttpClient client) throws UnirestException {
+		return HttpClientHelper.request(client, httpRequest, String.class);
+	}
+
 	public Future<HttpResponse<String>> asStringAsync() {
 		return HttpClientHelper.requestAsync(httpRequest, String.class, null);
 	}
@@ -66,6 +71,9 @@ public abstract class BaseRequest {
 
 	public HttpResponse<JsonNode> asJson() throws UnirestException {
 		return HttpClientHelper.request(httpRequest, JsonNode.class);
+	}
+	public HttpResponse<JsonNode> asJson(HttpClient client) throws UnirestException {
+		return HttpClientHelper.request(client, httpRequest, JsonNode.class);
 	}
 
 	public Future<HttpResponse<JsonNode>> asJsonAsync() {
@@ -80,6 +88,10 @@ public abstract class BaseRequest {
 		return HttpClientHelper.request(httpRequest, (Class) responseClass);
 	}
 
+	public <T> HttpResponse<T> asObject(HttpClient client, Class<? extends T> responseClass) throws UnirestException {
+		return HttpClientHelper.request(client, httpRequest, (Class) responseClass);
+	}
+
 	public <T> Future<HttpResponse<T>> asObjectAsync(Class<? extends T> responseClass) {
 		return HttpClientHelper.requestAsync(httpRequest, (Class) responseClass, null);
 	}
@@ -90,6 +102,10 @@ public abstract class BaseRequest {
 
 	public HttpResponse<InputStream> asBinary() throws UnirestException {
 		return HttpClientHelper.request(httpRequest, InputStream.class);
+	}
+
+	public HttpResponse<InputStream> asBinary(HttpClient client) throws UnirestException {
+		return HttpClientHelper.request(client, httpRequest, InputStream.class);
 	}
 
 	public Future<HttpResponse<InputStream>> asBinaryAsync() {


### PR DESCRIPTION
This covers resolution for two issues  which I have noticed while using Unirest : 

1. If http client has been supplied from outside using `Unirest.setHttpClient()` method and after that `Options.refresh()` is invoked then the new HttpClient is created and one supplied from outside is overridden. which leads to unpredictable behaviour.
2. Currently Unirest supports only one HTTP client which becomes bottleneck when your service needs to interact with multiple external services and configuration needs to be different across all Http clients.

Recently I faced an issue in which I needed different configuration (`MAX_PER_ROUTE`, `MAX_TOTAL`, `SOCKET_TIMEOUT` and  `CONNECTION_TIMEOUT`) for different external services that my application uses. 

In microservice architecture this kind of use case is quite obvious. In my case no. of external services were around 20.
