### PR TITLE
Added a support for a map of route parameter to the GetRequest class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: java
 
-jdk:
-  - openjdk6
-  - openjdk7
-  - oraclejdk7
-  - oraclejdk8
+jdk: oraclejdk8
 
 os:
   - linux

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
 					<fork>true</fork>
 					<meminitial>128m</meminitial>
 					<maxmem>512m</maxmem>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>1.6</source>
+					<target>1.6</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
 					<fork>true</fork>
 					<meminitial>128m</meminitial>
 					<maxmem>512m</maxmem>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
 					<fork>true</fork>
 					<meminitial>128m</meminitial>
 					<maxmem>512m</maxmem>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/src/main/java/com/mashape/unirest/request/GetRequest.java
+++ b/src/main/java/com/mashape/unirest/request/GetRequest.java
@@ -40,6 +40,12 @@ public class GetRequest extends HttpRequest {
 		return this;
 	}
 
+	public GetRequest routeParams(Map<String,String> routeParameters) {
+		for(Map.Entry<String,String> routeParameter :routeParameters.entrySet())
+			routeParam(routeParameter.getKey(),routeParameter.getValue());
+		return this;
+	}
+
 	@Override
 	public GetRequest header(String name, String value) {
 		return (GetRequest) super.header(name, value);

--- a/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
+++ b/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
@@ -49,6 +49,8 @@ import java.net.InetAddress;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -536,6 +538,17 @@ public class UnirestTest {
 	@Test
 	public void testPathParameters() throws UnirestException {
 		HttpResponse<JsonNode> jsonResponse = Unirest.get("http://httpbin.org/{method}").routeParam("method", "get").queryString("name", "Mark").asJson();
+
+		assertEquals(200, jsonResponse.getStatus());
+		assertEquals(jsonResponse.getBody().getObject().getJSONObject("args").getString("name"), "Mark");
+	}
+
+	@Test
+	public void testPathParameterMap() throws UnirestException {
+		Map<String,String> pathParameters = new HashMap<>();
+		pathParameters.put("method", "get");
+
+		HttpResponse<JsonNode> jsonResponse = Unirest.get("http://httpbin.org/{method}").routeParams(pathParameters).queryString("name", "Mark").asJson();
 
 		assertEquals(200, jsonResponse.getStatus());
 		assertEquals(jsonResponse.getBody().getObject().getJSONObject("args").getString("name"), "Mark");


### PR DESCRIPTION
I took the liberty to add a method to the GetRequest class, that takes in a map of strings as route parameters and sets them in the url.

I originally had a version using lambadas but I scraped that to stay in yout Java 5 theme.

If you have any feedback, please don't heasitate to ask.
