### PR TITLE
#272 Use Maven Shade Plugin to create standalone jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <fork>true</fork>
                     <meminitial>128m</meminitial>
@@ -229,16 +229,6 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
                 </configuration>
             </plugin>
             <plugin>
@@ -310,6 +300,48 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Will output 2 jars: the original, and the shaded one -->
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+
+                            <!-- final name of the shaded jar will be ${project.artifactId}-standalone -->
+                            <shadedClassifierName>standalone</shadedClassifierName>
+
+                            <relocations>
+                                <relocation>
+                                    <!-- Apache HttpClients -->
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>unirest.shaded.org.apache.http</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <!-- Jackson -->
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>unirest.shaded.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <!-- Google Guava -->
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>unirest.shaded.com.google.common</shadedPattern>
+                                </relocation>
+                            </relocations>
+
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
the standalone fat jar version of the build artifact will also relocate Apache HttpClient, Jackson, and Google Guava.

I think maven assembly plugin was not being used at all since it was not attached to any maven lifecycle phase, thus I removed it.

I figured since I do this kind of stuff for my own projects all the time, I may at least get the conversation in #272  started with a PR, with code that I'm very familiar with. 