### PR TITLE
Add a handler to deal with network connection and timeout failures

### DIFF
--- a/build/suppressions.xml
+++ b/build/suppressions.xml
@@ -9,4 +9,5 @@
     <suppress checks="MethodCount" files="JSONArray.java"/>
     <suppress checks="MethodCount" files="JSONObject.java"/>
     <suppress checks="FileLength" files="JSONObject.java"/>
+    <suppress checks="MethodLength" files="ApacheAsyncClient.java"/>
 </suppressions>

--- a/object-mapper-jackson/pom.xml
+++ b/object-mapper-jackson/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jackson.version>2.9.10</jackson.version>
+        <jackson.databind.version>2.9.10.1</jackson.databind.version>
         <main.dir>${project.basedir}</main.dir>
     </properties>
 
@@ -280,9 +281,9 @@
                             <rules>
                                 <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies">
                                     <excludeVulnerabilityIds>
-                                        <exclude>f4f0c103-c9d9-4308-bd8f-489f2a632680</exclude>
-                                        <exclude>07632245-fcef-4eb3-82b6-aadbbfd2b33e</exclude>
-                                        <exclude>ea932c13-011a-4c74-a092-48cd1c49adb4</exclude>
+<!--                                        <exclude>f4f0c103-c9d9-4308-bd8f-489f2a632680</exclude>-->
+<!--                                        <exclude>07632245-fcef-4eb3-82b6-aadbbfd2b33e</exclude>-->
+<!--                                        <exclude>ea932c13-011a-4c74-a092-48cd1c49adb4</exclude>-->
                                     </excludeVulnerabilityIds>
                                 </banVulnerable>
                             </rules>

--- a/unirest/pom.xml
+++ b/unirest/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/unirest/src/main/java/kong/unirest/BaseRequest.java
+++ b/unirest/src/main/java/kong/unirest/BaseRequest.java
@@ -314,10 +314,10 @@ abstract class BaseRequest<R extends HttpRequest> implements HttpRequest<R> {
 
 
 
-    private Function<RawResponse, HttpResponse<Object>> getConsumer(Consumer<RawResponse> consumer) {
+    private Function<RawResponse, HttpResponse<Empty>> getConsumer(Consumer<RawResponse> consumer) {
         return r -> {
             consumer.accept(r);
-            return null;
+            return new EmptyResponse(r);
         };
     }
 

--- a/unirest/src/main/java/kong/unirest/ErrorHandler.java
+++ b/unirest/src/main/java/kong/unirest/ErrorHandler.java
@@ -25,27 +25,29 @@
 
 package kong.unirest;
 
-public class ResponseSummary implements HttpResponseSummary {
-    private final int status;
-    private final String statusText;
+/**
+ * a error handler for various failure scenarios
+ */
+public interface ErrorHandler {
+    /**
+     * Handler method for response errors.
+     * Invoked if the response was NOT a 200-series response or a mapping exception happened.
+     * @param response The HTTP Response
+     */
+    void accept(HttpResponse<?> response);
 
-    ResponseSummary(RawResponse response) {
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
+    /**
+     * Handler method for request errors.
+     * Invoked if something terrible happened when attempting to make the request
+     * this could be due to connection failures or other systemic issues.
+     * No response is available in this case. Although though this handler a response may be attempted.
+     *
+     * @param request The current request object. Note that it may be in a partially consumed state and may not be re-requestable.
+     * @param e The exception that occured which failed the request.
+     * @return A HttpResponse object. Normally unirest thows the exception and ho response is returned.
+     */
+    default HttpResponse<?> handle(HttpRequest<?> request, Exception e){
+        throw new UnirestException(e);
     }
 
-    public ResponseSummary(HttpResponse response){
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
-    }
-
-    @Override
-    public int getStatus() {
-        return status;
-    }
-
-    @Override
-    public String getStatusText() {
-        return statusText;
-    }
 }

--- a/unirest/src/main/java/kong/unirest/SimpleHandler.java
+++ b/unirest/src/main/java/kong/unirest/SimpleHandler.java
@@ -25,27 +25,27 @@
 
 package kong.unirest;
 
-public class ResponseSummary implements HttpResponseSummary {
-    private final int status;
-    private final String statusText;
+import java.util.function.Consumer;
 
-    ResponseSummary(RawResponse response) {
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
+class SimpleHandler implements ErrorHandler {
+
+    private Consumer<HttpResponse<?>> consumer;
+
+    SimpleHandler(Consumer<HttpResponse<?>> consumer) {
+        this.consumer = consumer;
     }
 
-    public ResponseSummary(HttpResponse response){
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
-    }
-
-    @Override
-    public int getStatus() {
-        return status;
+    public SimpleHandler() {
+        this.consumer = r -> {};
     }
 
     @Override
-    public String getStatusText() {
-        return statusText;
+    public void accept(HttpResponse<?> response) {
+        consumer.accept(response);
+    }
+
+    @Override
+    public HttpResponse<?> handle(HttpRequest<?> request, Exception e) {
+        throw new UnirestException(e);
     }
 }

--- a/unirest/src/main/java/kong/unirest/apache/ApacheClient.java
+++ b/unirest/src/main/java/kong/unirest/apache/ApacheClient.java
@@ -131,7 +131,7 @@ public class ApacheClient extends BaseApacheClient implements Client {
             return httpResponse;
         } catch (Exception e) {
             metric.complete(null, e);
-            throw new UnirestException(e);
+            return handleError(config, request, e);
         } finally {
             requestObj.releaseConnection();
         }

--- a/unirest/src/main/java/kong/unirest/apache/BaseApacheClient.java
+++ b/unirest/src/main/java/kong/unirest/apache/BaseApacheClient.java
@@ -34,7 +34,6 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import java.util.function.Function;
 
 abstract class BaseApacheClient {
-
     protected RequestConfigFactory configFactory = new DefaultFactory();
 
 
@@ -66,9 +65,13 @@ abstract class BaseApacheClient {
     }
 
     protected <T> void handleError(Config config, HttpResponse<T> httpResponse) {
-        if(config.getErrorHandler() != null && !httpResponse.isSuccess()){
+        if(!httpResponse.isSuccess()){
             config.getErrorHandler().accept(httpResponse);
         }
+    }
+
+    protected <T> HttpResponse<T> handleError(Config config, HttpRequest<?> request, Exception e) {
+        return (HttpResponse<T>)config.getErrorHandler().handle(request, e);
     }
 
 

--- a/unirest/src/test/java/BehaviorTests/PostRequestHandlersTest.java
+++ b/unirest/src/test/java/BehaviorTests/PostRequestHandlersTest.java
@@ -96,6 +96,16 @@ public class PostRequestHandlersTest extends BddTest {
     }
 
     @Test
+    public void canUseWithConsumer(){
+        Error error = new Error();
+        Unirest.config().errorHandler(error);
+
+        Unirest.get(MockServer.INVALID_REQUEST).thenConsume(e -> {});
+
+        assertEquals(400, error.httpResponse.getStatus());
+    }
+
+    @Test
     public void canConfigureAGlobalErrorHandlerAsync()  throws Exception {
         Error error = new Error();
         Unirest.config().errorHandler(error);

--- a/unirest/src/test/java/BehaviorTests/TestErrorHandler.java
+++ b/unirest/src/test/java/BehaviorTests/TestErrorHandler.java
@@ -23,29 +23,23 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package kong.unirest;
+package BehaviorTests;
 
-public class ResponseSummary implements HttpResponseSummary {
-    private final int status;
-    private final String statusText;
+import kong.unirest.ErrorHandler;
+import kong.unirest.HttpRequest;
+import kong.unirest.HttpResponse;
 
-    ResponseSummary(RawResponse response) {
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
-    }
+public class TestErrorHandler implements ErrorHandler {
+    public Exception caught;
+    public HttpResponse<?> response;
+    @Override
+    public void accept(HttpResponse<?> response) {
 
-    public ResponseSummary(HttpResponse response){
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
     }
 
     @Override
-    public int getStatus() {
-        return status;
-    }
-
-    @Override
-    public String getStatusText() {
-        return statusText;
+    public HttpResponse<?> handle(HttpRequest<?> request, Exception e) {
+        caught = e;
+        return response;
     }
 }

--- a/unirest/src/test/java/kong/unirest/apache/MockAsyncClient.java
+++ b/unirest/src/test/java/kong/unirest/apache/MockAsyncClient.java
@@ -23,29 +23,23 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package kong.unirest;
+package kong.unirest.apache;
 
-public class ResponseSummary implements HttpResponseSummary {
-    private final int status;
-    private final String statusText;
+import kong.unirest.Config;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.nio.client.HttpAsyncClient;
 
-    ResponseSummary(RawResponse response) {
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockAsyncClient extends ApacheAsyncClient {
+    public MockAsyncClient(Config config) {
+        super(mock(HttpAsyncClient.class), config);
     }
 
-    public ResponseSummary(HttpResponse response){
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
-    }
-
-    @Override
-    public int getStatus() {
-        return status;
-    }
-
-    @Override
-    public String getStatusText() {
-        return statusText;
+    public void errorOnAccess(RuntimeException e) {
+        when(getClient().execute(any(HttpUriRequest.class), any(FutureCallback.class))).thenThrow(e);
     }
 }

--- a/unirest/src/test/java/kong/unirest/apache/MockedClient.java
+++ b/unirest/src/test/java/kong/unirest/apache/MockedClient.java
@@ -23,29 +23,33 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package kong.unirest;
+package kong.unirest.apache;
 
-public class ResponseSummary implements HttpResponseSummary {
-    private final int status;
-    private final String statusText;
+import kong.unirest.Config;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.mockito.Answers;
 
-    ResponseSummary(RawResponse response) {
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
+import java.io.IOException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockedClient extends ApacheClient {
+    public MockedClient(Config config) {
+        super(mock(HttpClient.class, Answers.RETURNS_DEEP_STUBS),
+                config,
+                mock(PoolingHttpClientConnectionManager.class, Answers.RETURNS_DEEP_STUBS),
+                mock(SyncIdleConnectionMonitorThread.class, Answers.RETURNS_DEEP_STUBS));
     }
 
-    public ResponseSummary(HttpResponse response){
-        this.status = response.getStatus();
-        this.statusText = response.getStatusText();
-    }
-
-    @Override
-    public int getStatus() {
-        return status;
-    }
-
-    @Override
-    public String getStatusText() {
-        return statusText;
+    public void errorOnAccess(RuntimeException e) {
+        try {
+            when(getClient().execute(any(HttpRequestBase.class))).thenThrow(e);
+        } catch (IOException io) {
+            throw new RuntimeException(io);
+        }
     }
 }


### PR DESCRIPTION
This adds a more robust error handler class that adds the ability to intercept total network failures like failing to connect. In today's world these errors just throw up out unirest.

It is possible with this to either craft a default response or re-attempt the connection, however keep in mind that Unirest ALREADY attempts to retry a network issue 3 times before throwing an exception so the odds that this handler would be successful with the same request are pretty bad.

This is more likely useful in logging such errors or executing backup plans 