### PR TITLE
Allow users to set the SSLContext

### DIFF
--- a/unirest/src/main/java/kong/unirest/Config.java
+++ b/unirest/src/main/java/kong/unirest/Config.java
@@ -228,9 +228,23 @@ public class Config {
         return this;
     }
 
-    public Config setSSLContext(SSLContext SSLContext) {
-        this.sslContext = SSLContext;
+    /**
+     * Set a custom SSLContext.
+     *
+     * @param ssl the SSLContext to use for custom ssl context
+     * @return this config object
+     * @throws UnirestConfigException if a keystore was already configured.
+     */
+    public Config sslContext(SSLContext ssl) {
+        verifySecurityConfig(this.keystore);
+        this.sslContext = ssl;
         return this;
+    }
+
+    private void verifySecurityConfig(Object thing) {
+        if(thing != null){
+            throw new UnirestConfigException("You may only configure a SSLContext OR a Keystore, but not both");
+        }
     }
 
     /**
@@ -239,8 +253,10 @@ public class Config {
      * @param store the keystore to use for a custom ssl context
      * @param password the password for the store
      * @return this config object
+     * @throws UnirestConfigException if a SSLContext was already configured.
      */
     public Config clientCertificateStore(KeyStore store, String password) {
+        verifySecurityConfig(this.sslContext);
         this.keystore = store;
         this.keystorePassword = () -> password;
         return this;
@@ -252,8 +268,10 @@ public class Config {
      * @param fileLocation the path keystore to use for a custom ssl context
      * @param password the password for the store
      * @return this config object
+     * @throws UnirestConfigException if a SSLContext was already configured.
      */
     public Config clientCertificateStore(String fileLocation, String password) {
+        verifySecurityConfig(this.sslContext);
         try (InputStream keyStoreStream = Util.getFileInputStream(fileLocation)) {
             this.keystorePassword = () -> password;
             this.keystore = KeyStore.getInstance("PKCS12");

--- a/unirest/src/main/java/kong/unirest/Config.java
+++ b/unirest/src/main/java/kong/unirest/Config.java
@@ -31,6 +31,7 @@ import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.client.HttpClient;
 import org.apache.http.nio.client.HttpAsyncClient;
 
+import javax.net.ssl.SSLContext;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
@@ -80,6 +81,7 @@ public class Config {
     private UniMetric metrics = new NoopMetric();
     private long ttl = -1;
     private Consumer<HttpResponse<?>> errorHandler;
+    private SSLContext sslContext;
 
     public Config() {
         setDefaults();
@@ -100,6 +102,7 @@ public class Config {
         verifySsl = true;
         keystore = null;
         keystorePassword = null;
+        sslContext = null;
         errorHandler = null;
         this.objectMapper = Optional.of(new JsonObjectMapper());
         try {
@@ -222,6 +225,11 @@ public class Config {
      */
     public Config setObjectMapper(ObjectMapper om) {
         this.objectMapper = Optional.ofNullable(om);
+        return this;
+    }
+
+    public Config setSSLContext(SSLContext SSLContext) {
+        this.sslContext = SSLContext;
         return this;
     }
 
@@ -748,5 +756,9 @@ public class Config {
 
     public Consumer<HttpResponse<?>> getErrorHandler() {
         return errorHandler;
+    }
+
+    public SSLContext getSslContext() {
+        return sslContext;
     }
 }

--- a/unirest/src/main/java/kong/unirest/apache/ApacheClient.java
+++ b/unirest/src/main/java/kong/unirest/apache/ApacheClient.java
@@ -81,9 +81,6 @@ public class ApacheClient extends BaseApacheClient implements Client {
         this.syncMonitor = null;
     }
 
-
-
-
     private void setOptions(HttpClientBuilder cb) {
         security.configureSecurity(cb);
         if (!config.isAutomaticRetries()) {

--- a/unirest/src/main/java/kong/unirest/apache/SecurityConfig.java
+++ b/unirest/src/main/java/kong/unirest/apache/SecurityConfig.java
@@ -67,7 +67,7 @@ class SecurityConfig {
         try {
             if (!config.isVerifySsl()) {
                 return createDisabledSSLContext();
-            } else if (config.getKeystore() != null) {
+            } else if (config.getKeystore() != null || config.getSslContext() != null) {
                 return createCustomSslContext();
             } else {
                 return createDefaultRegistry();
@@ -110,15 +110,19 @@ class SecurityConfig {
     }
     private SSLContext createSslContext() {
         if(sslContext == null) {
-            try {
-                char[] pass = Optional.ofNullable(config.getKeyStorePassword())
-                        .map(String::toCharArray)
-                        .orElse(null);
-                sslContext = SSLContexts.custom()
-                        .loadKeyMaterial(config.getKeystore(), pass)
-                        .build();
-            } catch (Exception e) {
-                throw new UnirestConfigException(e);
+            if(config.getSslContext() != null){
+                sslContext = config.getSslContext();
+            } else {
+                try {
+                    char[] pass = Optional.ofNullable(config.getKeyStorePassword())
+                            .map(String::toCharArray)
+                            .orElse(null);
+                    sslContext = SSLContexts.custom()
+                            .loadKeyMaterial(config.getKeystore(), pass)
+                            .build();
+                } catch (Exception e) {
+                    throw new UnirestConfigException(e);
+                }
             }
         }
         return sslContext;

--- a/unirest/src/test/java/BehaviorTests/CertificateTests.java
+++ b/unirest/src/test/java/BehaviorTests/CertificateTests.java
@@ -69,6 +69,7 @@ public class CertificateTests extends BddTest {
                 .ifSuccess(r -> System.out.println(" woot "));;
     }
 
+
     @Test
     public void canLoadKeyStoreByPath() {
         Unirest.config().clientCertificateStore("src/test/resources/certs/badssl.com-client.p12", "badssl.com");
@@ -77,6 +78,18 @@ public class CertificateTests extends BddTest {
                 .asString()
                 .ifFailure(r -> Assert.fail(r.getStatus() + " request failed " + r.getBody()))
                 .ifSuccess(r -> System.out.println(" woot "));;
+    }
+
+    @Test
+    public void loadWithSSLContext() throws Exception {
+        SSLContext sslContext = SSLContexts.custom()
+                .loadKeyMaterial(readStore(), "badssl.com".toCharArray()) // use null as second param if you don't have a separate key password
+                .build();
+
+        Unirest.config().setSSLContext(sslContext);
+
+        int response = Unirest.get("https://client.badssl.com/").asEmpty().getStatus();
+        assertEquals(200, response);
     }
 
     @Test

--- a/unirest/src/test/java/BehaviorTests/CertificateTests.java
+++ b/unirest/src/test/java/BehaviorTests/CertificateTests.java
@@ -49,8 +49,6 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
-import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyStore;
 
@@ -86,7 +84,7 @@ public class CertificateTests extends BddTest {
                 .loadKeyMaterial(readStore(), "badssl.com".toCharArray()) // use null as second param if you don't have a separate key password
                 .build();
 
-        Unirest.config().setSSLContext(sslContext);
+        Unirest.config().sslContext(sslContext);
 
         int response = Unirest.get("https://client.badssl.com/").asEmpty().getStatus();
         assertEquals(200, response);

--- a/unirest/src/test/java/kong/unirest/ConfigTest.java
+++ b/unirest/src/test/java/kong/unirest/ConfigTest.java
@@ -41,7 +41,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.security.KeyStore;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
@@ -265,6 +267,34 @@ public class ConfigTest {
 
         config.proxy("local3", 7777, "barb", "12345");
         assertProxy("local3", 7777, "barb", "12345");
+    }
+
+    @Test
+    public void cannotConfigASslContextIfAKeystoreIsPresent() {
+        KeyStore store = mock(KeyStore.class);
+        SSLContext context = mock(SSLContext.class);
+
+        config.clientCertificateStore(store, "foo");
+
+        TestUtil.assertException(() -> config.sslContext(context),
+                UnirestConfigException.class,
+                "You may only configure a SSLContext OR a Keystore, but not both");
+    }
+
+    @Test
+    public void cannotConfigAKeyStoreIfASSLContextIsPresent() {
+        KeyStore store = mock(KeyStore.class);
+        SSLContext context = mock(SSLContext.class);
+
+        config.sslContext(context);
+
+        TestUtil.assertException(() -> config.clientCertificateStore(store, "foo"),
+                UnirestConfigException.class,
+                "You may only configure a SSLContext OR a Keystore, but not both");
+
+        TestUtil.assertException(() -> config.clientCertificateStore("/a/path/file.pk12", "foo"),
+                UnirestConfigException.class,
+                "You may only configure a SSLContext OR a Keystore, but not both");
     }
 
     private void assertProxy(String host, Integer port, String username, String password) {


### PR DESCRIPTION
In order to properly test this we need the Client Certificate from badssl.com updated. It is currently expired: https://github.com/chromium/badssl.com/issues/422

