### PR TITLE
Headers: add toString() for nicer logging/debugging

### DIFF
--- a/unirest/src/main/java/kong/unirest/Headers.java
+++ b/unirest/src/main/java/kong/unirest/Headers.java
@@ -157,6 +157,18 @@ public class Headers {
         headers.removeAll(header);
     }
 
+    /**
+     * @return list all headers like this: <pre>Content-Length: 42
+     * Cache-Control: no-cache
+     * ...</pre>
+     */
+    @Override
+    public String toString() {
+       final StringBuilder sb = new StringBuilder();
+        headers.forEach(header -> sb.append(header.getName()).append(": ").append(header.getValue()).append(System.lineSeparator()));
+        return sb.toString();
+    }
+
     static class Entry implements Header {
 
         private final String name;


### PR DESCRIPTION
nobody is interested in seeing things like:
`kong.unirest.Headers@4dffff9`
or
`[kong.unirest.Headers$Entry@2904bc56, kong.unirest.Headers$Entry@7bb25046, kong.unirest.Headers$Entry@69b1e8f8]`

Let's improve this.

Thanks,
Hilmar