### PR TITLE
Parsing error occurs when POST response is empty gzip content type

### DIFF
--- a/unirest/src/main/java/kong/unirest/apache/ApacheResponse.java
+++ b/unirest/src/main/java/kong/unirest/apache/ApacheResponse.java
@@ -81,10 +81,12 @@ class ApacheResponse extends RawResponseBase {
         }
         try {
             InputStream is = getContent();
-            if (isGzipped(getEncoding())) {
-                is = new GZIPInputStream(getContent());
+            byte[] bytes = getBytes(is);
+            if (bytes.length > 0 && isGzipped(getEncoding())) {
+              is = new GZIPInputStream(new ByteArrayInputStream(bytes));
+              return getBytes(is);
             }
-            return getBytes(is);
+            return bytes;
         } catch (IOException e2) {
             throw new UnirestException(e2);
         } finally {

--- a/unirest/src/main/java/kong/unirest/apache/ApacheResponse.java
+++ b/unirest/src/main/java/kong/unirest/apache/ApacheResponse.java
@@ -81,12 +81,10 @@ class ApacheResponse extends RawResponseBase {
         }
         try {
             InputStream is = getContent();
-            byte[] bytes = getBytes(is);
-            if (bytes.length > 0 && isGzipped(getEncoding())) {
-              is = new GZIPInputStream(new ByteArrayInputStream(bytes));
-              return getBytes(is);
+            if (is.available() > 0 && isGzipped(getEncoding())) {
+              is = new GZIPInputStream(getContent());
             }
-            return bytes;
+            return getBytes(is);
         } catch (IOException e2) {
             throw new UnirestException(e2);
         } finally {

--- a/unirest/src/test/java/BehaviorTests/GZipTest.java
+++ b/unirest/src/test/java/BehaviorTests/GZipTest.java
@@ -26,12 +26,38 @@
 package BehaviorTests;
 
 import kong.unirest.HttpResponse;
+import kong.unirest.ObjectMapper;
 import kong.unirest.Unirest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Map;
 
 public class GZipTest extends BddTest {
+    @Test
+    public void emptyGzip() {
+        ObjectMapper om = Unirest.config().getObjectMapper();
+        ObjectMapper omWithNull = new ObjectMapper() {
+          @Override
+          public <T> T readValue(String value, Class<T> valueType) {
+            return value == null || value.trim().isEmpty() ? null : om.readValue(value, valueType);
+          }
+          @Override
+          public String writeValue(Object value) {
+            return om.writeValue(value);
+          }
+        };
+        Unirest.config().setObjectMapper(omWithNull);
+        HttpResponse<Map<?,?>> resp = Unirest.post(MockServer.EMPTY_GZIP)
+                .header("Content-Type", "application/json")
+                .accept( "application/json")
+                .asObject(Map.class);
+        Unirest.config().setObjectMapper(om);
+        assertFalse(resp.getParsingError().isPresent());
+    }
+
     @Test
     public void testGzip() {
         HttpResponse<RequestCapture> resp = Unirest.get(MockServer.GZIP)

--- a/unirest/src/test/java/BehaviorTests/GZipTest.java
+++ b/unirest/src/test/java/BehaviorTests/GZipTest.java
@@ -38,24 +38,10 @@ import java.util.Map;
 public class GZipTest extends BddTest {
     @Test
     public void emptyGzip() {
-        ObjectMapper om = Unirest.config().getObjectMapper();
-        ObjectMapper omWithNull = new ObjectMapper() {
-          @Override
-          public <T> T readValue(String value, Class<T> valueType) {
-            return value == null || value.trim().isEmpty() ? null : om.readValue(value, valueType);
-          }
-          @Override
-          public String writeValue(Object value) {
-            return om.writeValue(value);
-          }
-        };
-        Unirest.config().setObjectMapper(omWithNull);
-        HttpResponse<Map<?,?>> resp = Unirest.post(MockServer.EMPTY_GZIP)
-                .header("Content-Type", "application/json")
-                .accept( "application/json")
-                .asObject(Map.class);
-        Unirest.config().setObjectMapper(om);
-        assertFalse(resp.getParsingError().isPresent());
+        HttpResponse<String> result = Unirest.post(MockServer.EMPTY_GZIP)
+                .asString();
+        assertFalse(result.getParsingError().isPresent());
+        assertEquals("", result.getBody());
     }
 
     @Test

--- a/unirest/src/test/java/BehaviorTests/GZipTest.java
+++ b/unirest/src/test/java/BehaviorTests/GZipTest.java
@@ -26,14 +26,11 @@
 package BehaviorTests;
 
 import kong.unirest.HttpResponse;
-import kong.unirest.ObjectMapper;
 import kong.unirest.Unirest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-
-import java.util.Map;
 
 public class GZipTest extends BddTest {
     @Test

--- a/unirest/src/test/java/BehaviorTests/MockServer.java
+++ b/unirest/src/test/java/BehaviorTests/MockServer.java
@@ -68,6 +68,7 @@ public class MockServer {
 	public static final String ERROR_RESPONSE = HOST + "/error";
 	public static final String DELETE = HOST + "/delete";
 	public static final String GZIP = HOST + "/gzip";
+	public static final String EMPTY_GZIP = HOST + "/empty-gzip";
 	public static final String PATCH = HOST + "/patch";
 	public static final String INVALID_REQUEST = HOST + "/invalid";
 	public static final String PASSED_PATH_PARAM = GET + "/{params}/passed";
@@ -98,6 +99,7 @@ public class MockServer {
 		post("/post", MockServer::jsonResponse);
 		get("/get", MockServer::jsonResponse);
 		get("/gzip", MockServer::gzipResponse);
+		post("/empty-gzip", MockServer::emptyGzipResponse);
 		get("/redirect", MockServer::redirect);
 		patch("/patch", MockServer::jsonResponse);
 		get("/invalid", MockServer::inValid);
@@ -193,6 +195,15 @@ public class MockServer {
 		return "You did something bad";
 	}
 
+  private static Object emptyGzipResponse(Request request, Response response) throws Exception {
+    response.raw().setHeader("Content-Encoding", "gzip");
+    response.raw().setContentType("application/json");
+    response.raw().setStatus(200);
+    response.raw().getOutputStream().write(new byte[0]);
+    response.raw().getOutputStream().close();
+    return null;
+  }
+
 	private static Object gzipResponse(Request request, Response response) {
 		response.header("Content-Encoding", "gzip");
 		return jsonResponse(request, response);
@@ -248,7 +259,7 @@ public class MockServer {
 	}
 
 	public static void main(String[] args){
-		
+
 	}
 
 	public static void expectCookie(String name, String value) {

--- a/unirest/src/test/java/BehaviorTests/MockServer.java
+++ b/unirest/src/test/java/BehaviorTests/MockServer.java
@@ -199,7 +199,6 @@ public class MockServer {
     response.raw().setHeader("Content-Encoding", "gzip");
     response.raw().setContentType("application/json");
     response.raw().setStatus(200);
-    response.raw().getOutputStream().write(new byte[0]);
     response.raw().getOutputStream().close();
     return null;
   }


### PR DESCRIPTION
Fixes https://github.com/Kong/unirest-java/issues/349