### PR TITLE
Support for custom ciphers and protocols for https requests

### DIFF
--- a/build/checkstyle.xml
+++ b/build/checkstyle.xml
@@ -63,7 +63,7 @@
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="FileLength">
         <!-- This can't ignore javadocs so it's kind of stupid -->
-        <property name="max" value="1000"/>
+        <property name="max" value="1100"/>
     </module>
 
     <!-- Checks for whitespace                               -->

--- a/unirest/src/main/java/kong/unirest/Config.java
+++ b/unirest/src/main/java/kong/unirest/Config.java
@@ -79,6 +79,8 @@ public class Config {
     private UniMetric metrics = new NoopMetric();
     private long ttl = -1;
     private SSLContext sslContext;
+    private String[] ciphers;
+    private String[] protocols;
     private CompoundInterceptor interceptor = new CompoundInterceptor();
     private HostnameVerifier hostnameVerifier;
     private String defaultBaseUrl;
@@ -105,6 +107,8 @@ public class Config {
         keystore = null;
         keystorePassword = null;
         sslContext = null;
+        ciphers = null;
+        protocols = null;
         interceptor = new CompoundInterceptor();
 
         this.objectMapper = Optional.of(new JsonObjectMapper());
@@ -253,6 +257,26 @@ public class Config {
      */
     public Config hostnameVerifier(HostnameVerifier value) {
         this.hostnameVerifier = value;
+        return this;
+    }
+
+    /**
+     * Set a custom array of ciphers
+     * @param values the array of ciphers
+     * @return this config object
+     */
+    public Config ciphers(String... values) {
+        this.ciphers = values;
+        return this;
+    }
+
+    /**
+     * Set a custom array of protocols
+     * @param values the array of protocols
+     * @return this config object
+     */
+    public Config protocols(String... values) {
+        this.protocols = values;
         return this;
     }
 
@@ -968,6 +992,20 @@ public class Config {
      */
     public HostnameVerifier getHostnameVerifier() {
         return hostnameVerifier;
+    }
+
+    /**
+     * @return the ciphers for the SSL connection configuration
+     */
+    public String[] getCiphers() {
+        return ciphers;
+    }
+
+    /**
+     * @return the protocols for the SSL connection configuration
+     */
+    public String[] getProtocols() {
+        return protocols;
     }
 
     /**

--- a/unirest/src/main/java/kong/unirest/apache/SecurityConfig.java
+++ b/unirest/src/main/java/kong/unirest/apache/SecurityConfig.java
@@ -106,7 +106,7 @@ class SecurityConfig {
 
     private SSLConnectionSocketFactory getSocketFactory() {
         if(sslSocketFactory == null) {
-            sslSocketFactory = new SSLConnectionSocketFactory(createSslContext(), getHostnameVerifier());
+            sslSocketFactory = new SSLConnectionSocketFactory(createSslContext(), config.getProtocols(), config.getCiphers(), getHostnameVerifier());
         }
         return sslSocketFactory;
     }

--- a/unirest/src/test/java/BehaviorTests/CertificateTests.java
+++ b/unirest/src/test/java/BehaviorTests/CertificateTests.java
@@ -54,7 +54,9 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import java.io.InputStream;
 import java.security.KeyStore;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @Disabled // dont normally run these because they depend on badssl.com
 class CertificateTests extends BddTest {
@@ -141,6 +143,20 @@ class CertificateTests extends BddTest {
                 .sslContext(sslContext)
                 .protocols("TLSv1.2")
                 .ciphers("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
+
+        GetRequest request = Unirest.get("https://client.badssl.com/");
+        assertThrows(UnirestException.class, request::asEmpty);
+    }
+
+    @Test
+    void clientPreventsToUseUnsafeProtocol() throws Exception {
+        SSLContext sslContext = SSLContexts.custom()
+                .loadKeyMaterial(readStore(), "badssl.com".toCharArray()) // use null as second param if you don't have a separate key password
+                .build();
+
+        Unirest.config()
+                .sslContext(sslContext)
+                .protocols("SSLv3");
 
         GetRequest request = Unirest.get("https://client.badssl.com/");
         assertThrows(UnirestException.class, request::asEmpty);

--- a/unirest/src/test/java/BehaviorTests/CertificateTests.java
+++ b/unirest/src/test/java/BehaviorTests/CertificateTests.java
@@ -56,10 +56,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Disabled // dont normally run these because they depend on badssl.com
-public class CertificateTests extends BddTest {
+class CertificateTests extends BddTest {
 
     @Test
-    public void canDoClientCertificates() throws Exception {
+    void canDoClientCertificates() throws Exception {
         Unirest.config().clientCertificateStore(readStore(), "badssl.com");
 
         Unirest.get("https://client.badssl.com/")
@@ -70,7 +70,7 @@ public class CertificateTests extends BddTest {
 
 
     @Test
-    public void canLoadKeyStoreByPath() {
+    void canLoadKeyStoreByPath() {
         Unirest.config().clientCertificateStore("src/test/resources/certs/badssl.com-client.p12", "badssl.com");
 
         Unirest.get("https://client.badssl.com/")
@@ -80,7 +80,7 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void loadWithSSLContext() throws Exception {
+    void loadWithSSLContext() throws Exception {
         SSLContext sslContext = SSLContexts.custom()
                 .loadKeyMaterial(readStore(), "badssl.com".toCharArray()) // use null as second param if you don't have a separate key password
                 .build();
@@ -92,7 +92,46 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void canSetHoestNameVerifyer() throws Exception {
+    void loadWithSSLContextAndProtocol() throws Exception {
+        SSLContext sslContext = SSLContexts.custom()
+                .loadKeyMaterial(readStore(), "badssl.com".toCharArray()) // use null as second param if you don't have a separate key password
+                .build();
+
+        Unirest.config().sslContext(sslContext).protocols("TLSv1.2");
+
+        int response = Unirest.get("https://client.badssl.com/").asEmpty().getStatus();
+        assertEquals(200, response);
+    }
+
+    @Test
+    void loadWithSSLContextAndCipher() throws Exception {
+        SSLContext sslContext = SSLContexts.custom()
+                .loadKeyMaterial(readStore(), "badssl.com".toCharArray()) // use null as second param if you don't have a separate key password
+                .build();
+
+        Unirest.config().sslContext(sslContext).ciphers("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+
+        int response = Unirest.get("https://client.badssl.com/").asEmpty().getStatus();
+        assertEquals(200, response);
+    }
+
+    @Test
+    void loadWithSSLContextAndCipherAndProtocol() throws Exception {
+        SSLContext sslContext = SSLContexts.custom()
+                .loadKeyMaterial(readStore(), "badssl.com".toCharArray()) // use null as second param if you don't have a separate key password
+                .build();
+
+        Unirest.config()
+                .sslContext(sslContext)
+                .protocols("TLSv1.2")
+                .ciphers("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+
+        int response = Unirest.get("https://client.badssl.com/").asEmpty().getStatus();
+        assertEquals(200, response);
+    }
+
+    @Test
+    void canSetHoestNameVerifyer() throws Exception {
         Unirest.config().hostnameVerifier(new NoopHostnameVerifier());
 
         int response = Unirest.get("https://badssl.com/").asEmpty().getStatus();
@@ -100,7 +139,7 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void rawApacheClientCert() throws Exception {
+    void rawApacheClientCert() throws Exception {
         SSLContext sslContext = SSLContexts.custom()
                 .loadKeyMaterial(readStore(), "badssl.com".toCharArray()) // use null as second param if you don't have a separate key password
                 .build();
@@ -117,7 +156,7 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void rawApacheWithConnectionManager() throws Exception {
+    void rawApacheWithConnectionManager() throws Exception {
         SSLContext sc = SSLContexts.custom()
                 .loadKeyMaterial(readStore(), "badssl.com".toCharArray()) // use null as second param if you don't have a separate key password
                 .build();
@@ -151,7 +190,7 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void badName() {
+    void badName() {
         fails("https://wrong.host.badssl.com/",
                 SSLPeerUnverifiedException.class,
                 "javax.net.ssl.SSLPeerUnverifiedException: " +
@@ -162,7 +201,7 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void expired() {
+    void expired() {
         fails("https://expired.badssl.com/",
                 SSLHandshakeException.class,
                 "javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: " +
@@ -172,7 +211,7 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void selfSigned() {
+    void selfSigned() {
         fails("https://self-signed.badssl.com/",
                 SSLHandshakeException.class,
                 "javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: " +
@@ -183,7 +222,7 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void badNameAsync() {
+    void badNameAsync() {
         failsAsync("https://wrong.host.badssl.com/",
                 SSLPeerUnverifiedException.class,
                 "javax.net.ssl.SSLPeerUnverifiedException: " +
@@ -194,7 +233,7 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void expiredAsync() {
+    void expiredAsync() {
         failsAsync("https://expired.badssl.com/",
                 SSLHandshakeException.class,
                 "javax.net.ssl.SSLHandshakeException: General SSLEngine problem");
@@ -203,7 +242,7 @@ public class CertificateTests extends BddTest {
     }
 
     @Test
-    public void selfSignedAsync() {
+    void selfSignedAsync() {
         failsAsync("https://self-signed.badssl.com/",
                 SSLHandshakeException.class,
                 "javax.net.ssl.SSLHandshakeException: General SSLEngine problem");


### PR DESCRIPTION
This pull request is an implementation for the following feature request: https://github.com/Kong/unirest-java/issues/380

Usage would be for example:
```
Unirest.config()
    .sslContext(sslContext)
    .protocols("TLSv1.2")
    .ciphers("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
```

This will force your client to communicate over TLSv1.2 and TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 with the server or else it will fail. This setup will also prevent your client to communicate with older protocols such as TLSv1.1 and TLSv1
