### PR TITLE
Removed redundant access modifiers, fixed typos and simplified some assertions

### DIFF
--- a/object-mapper-gson/src/test/java/kong/unirest/gson/GsonObjectMapperTest.java
+++ b/object-mapper-gson/src/test/java/kong/unirest/gson/GsonObjectMapperTest.java
@@ -61,11 +61,11 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class GsonObjectMapperTest {
+class GsonObjectMapperTest {
     private GsonObjectMapper om = new GsonObjectMapper();
 
     @Test
-    public void canWrite() throws Exception {
+    void canWrite() throws Exception {
         TestMe test = new TestMe("foo", 42, new TestMe("bar", 666, null));
 
         String json = om.writeValue(test);
@@ -78,7 +78,7 @@ public class GsonObjectMapperTest {
     }
 
     @Test
-    public void canRead(){
+    void canRead(){
         TestMe test = om.readValue("{\"text\":\"foo\",\"nmbr\":42,\"another\":{\"text\":\"bar\",\"nmbr\":666}}",
                 TestMe.class);
 
@@ -90,7 +90,7 @@ public class GsonObjectMapperTest {
     }
 
     @Test
-    public void canReadGenerics(){
+    void canReadGenerics(){
         List<TestMe> testList = om.readValue("[{\"text\":\"foo\",\"nmbr\":42,\"another\":{\"text\":\"bar\",\"nmbr\":666,\"another\":null}}]",
                 new GenericType<List<TestMe>>(){});
 
@@ -104,7 +104,7 @@ public class GsonObjectMapperTest {
     }
 
     @Test
-    public void serializeNulls() {
+    void serializeNulls() {
         Gson gson = new GsonBuilder()
                 .serializeNulls()
                 .create();

--- a/object-mapper-jackson/src/test/java/kong/unirest/jackson/JacksonObjectMapperTest.java
+++ b/object-mapper-jackson/src/test/java/kong/unirest/jackson/JacksonObjectMapperTest.java
@@ -61,11 +61,11 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JacksonObjectMapperTest {
+class JacksonObjectMapperTest {
     private JacksonObjectMapper om = new JacksonObjectMapper();
 
     @Test
-    public void canWrite() throws JSONException {
+    void canWrite() throws JSONException {
         TestMe test = new TestMe("foo", 42, new TestMe("bar", 666, null));
 
         String json = om.writeValue(test);
@@ -78,7 +78,7 @@ public class JacksonObjectMapperTest {
     }
 
     @Test
-    public void canRead(){
+    void canRead(){
         TestMe test = om.readValue("{\"text\":\"foo\",\"nmbr\":42,\"another\":{\"text\":\"bar\",\"nmbr\":666,\"another\":null}}",
                 TestMe.class);
 
@@ -90,7 +90,7 @@ public class JacksonObjectMapperTest {
     }
 
     @Test
-    public void canReadGenerics(){
+    void canReadGenerics(){
         List<TestMe> testList = om.readValue("[{\"text\":\"foo\",\"nmbr\":42,\"another\":{\"text\":\"bar\",\"nmbr\":666,\"another\":null}}]",
                 new GenericType<List<TestMe>>(){});
 
@@ -104,7 +104,7 @@ public class JacksonObjectMapperTest {
     }
 
     @Test
-    public void configSoItFails() {
+    void configSoItFails() {
         ObjectMapper jom = new ObjectMapper();
         jom.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         JacksonObjectMapper j = new JacksonObjectMapper(jom);

--- a/unirest-mocks/src/test/java/kong/tests/AssertTest.java
+++ b/unirest-mocks/src/test/java/kong/tests/AssertTest.java
@@ -35,10 +35,10 @@ import static kong.unirest.HttpMethod.POST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class AssertTest extends Base {
+class AssertTest extends Base {
 
     @Test
-    public void canAssertANumberOfTimes() {
+    void canAssertANumberOfTimes() {
         Unirest.get(path).asEmpty();
         Unirest.get(path).asEmpty();
 
@@ -55,27 +55,27 @@ public class AssertTest extends Base {
     }
 
     @Test
-    public void noExpectationsAtAll() {
+    void noExpectationsAtAll() {
         Unirest.get(path).asEmpty();
         client.verifyAll();
 
     }
 
     @Test
-    public void noExpectation() {
+    void noExpectation() {
         client.expect(GET, otherPath);
         assertException(() -> client.verifyAll(),
                 "A expectation was never invoked! GET http://other\n");
     }
 
     @Test
-    public void noInvocationHappened() {
+    void noInvocationHappened() {
         assertException(() -> client.assertThat(GET, path),
                 "No Matching Invocation:: GET http://basic");
     }
 
     @Test
-    public void assertHeader() {
+    void assertHeader() {
         Unirest.get(path).header("monster", "grover").asEmpty();
 
         Assert expect = client.assertThat(GET, path);
@@ -86,7 +86,7 @@ public class AssertTest extends Base {
     }
 
     @Test
-    public void canSetHeaderExpectationOnExpects() {
+    void canSetHeaderExpectationOnExpects() {
         client.expect(GET, path).header("monster", "grover");
 
         assertException(() -> client.verifyAll(),
@@ -102,7 +102,7 @@ public class AssertTest extends Base {
 
 
     @Test
-    public void canExpectQueryParams() {
+    void canExpectQueryParams() {
         client.expect(GET, path).queryString("monster", "grover");
 
         Unirest.get(path).asEmpty();
@@ -115,7 +115,7 @@ public class AssertTest extends Base {
     }
 
     @Test
-    public void expectBody() {
+    void expectBody() {
         client.expect(POST, path)
                 .body("foo")
                 .thenReturn("bar");

--- a/unirest-mocks/src/test/java/kong/tests/AsyncTest.java
+++ b/unirest-mocks/src/test/java/kong/tests/AsyncTest.java
@@ -31,7 +31,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AsyncTest extends Base {
+class AsyncTest extends Base {
+
     @Test
     void canExpectAsync() throws Exception {
         client.expect(HttpMethod.GET, path).thenReturn("Hey Ma");

--- a/unirest-mocks/src/test/java/kong/tests/Base.java
+++ b/unirest-mocks/src/test/java/kong/tests/Base.java
@@ -26,9 +26,7 @@
 package kong.tests;
 
 import kong.unirest.MockClient;
-import kong.unirest.Unirest;
 import kong.unirest.UnirestAssertion;
-import kong.unirest.UnirestInstance;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -63,7 +61,7 @@ public class Base {
         try{
             runnable.run();
             fail("Expected exception but got none.");
-        } catch (UnirestAssertion e){ }
+        } catch (UnirestAssertion ignored){ }
     }
 
     @FunctionalInterface

--- a/unirest-mocks/src/test/java/kong/tests/ErrorTest.java
+++ b/unirest-mocks/src/test/java/kong/tests/ErrorTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import static kong.unirest.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ErrorTest extends Base {
+class ErrorTest extends Base {
 
     @Test
     void mapError() {
@@ -45,7 +45,7 @@ public class ErrorTest extends Base {
         assertEquals("Boo!", err.say);
     }
 
-    private class ErrorObj {
+    private static class ErrorObj {
         public String say;
 
         public ErrorObj(String say) {

--- a/unirest-mocks/src/test/java/kong/tests/ExpectedResponseTest.java
+++ b/unirest-mocks/src/test/java/kong/tests/ExpectedResponseTest.java
@@ -35,7 +35,8 @@ import static kong.unirest.HttpMethod.GET;
 import static kong.unirest.HttpStatus.BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ExpectedResponseTest extends Base {
+class ExpectedResponseTest extends Base {
+
     @Test
     void canExpectErrors() {
         client.expect(HttpMethod.GET, path).thenReturn().withStatus(BAD_REQUEST, "oh noes");
@@ -57,7 +58,7 @@ public class ExpectedResponseTest extends Base {
     }
 
     @Test
-    public void simpleGetString() {
+    void simpleGetString() {
         client.expect(HttpMethod.GET, path)
                 .thenReturn("Hello World");
 
@@ -65,7 +66,7 @@ public class ExpectedResponseTest extends Base {
     }
 
     @Test
-    public void simpleGetBytes() {
+    void simpleGetBytes() {
         client.expect(HttpMethod.GET, path)
                 .thenReturn("Hello World");
 
@@ -74,7 +75,7 @@ public class ExpectedResponseTest extends Base {
     }
 
     @Test
-    public void simpleJson() {
+    void simpleJson() {
         client.expect(HttpMethod.GET, path)
                 .thenReturn("{\"fruit\": \"apple\"}");
 
@@ -83,7 +84,7 @@ public class ExpectedResponseTest extends Base {
     }
 
     @Test
-    public void setReturnAsJson() {
+    void setReturnAsJson() {
         client.expect(HttpMethod.GET, path)
                 .thenReturn(new JSONObject("{\"fruit\": \"apple\"}"));
 
@@ -92,13 +93,13 @@ public class ExpectedResponseTest extends Base {
     }
 
     @Test
-    public void canPassInAndReturnObjectsAsJson() {
+    void canPassInAndReturnObjectsAsJson() {
         client.expect(HttpMethod.GET, path)
                 .thenReturn(new Pojo("apple"));
     }
 
     @Test
-    public void canSetResponseHeaders() {
+    void canSetResponseHeaders() {
         client.expect(GET, path)
                 .thenReturn("foo")
                 .withHeader("monster", "grover");
@@ -109,7 +110,7 @@ public class ExpectedResponseTest extends Base {
     }
 
     @Test
-    public void canReturnEmptyWithHeaders() {
+    void canReturnEmptyWithHeaders() {
         client.expect(GET, path)
                 .thenReturn()
                 .withHeader("monster", "grover");

--- a/unirest-mocks/src/test/java/kong/tests/MetricsTest.java
+++ b/unirest-mocks/src/test/java/kong/tests/MetricsTest.java
@@ -30,7 +30,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MetricsTest extends Base {
+class MetricsTest extends Base {
+
     boolean wasCalled = false;
 
     @Test

--- a/unirest-mocks/src/test/java/kong/tests/MockClientInterceptorIssueTest.java
+++ b/unirest-mocks/src/test/java/kong/tests/MockClientInterceptorIssueTest.java
@@ -26,14 +26,13 @@
 package kong.tests;
 
 import kong.unirest.*;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class MockClientInterceptorIssueTest {
+class MockClientInterceptorIssueTest {
 
     private final ExampleInterceptor interceptor = new ExampleInterceptor();
 
@@ -61,7 +60,7 @@ public class MockClientInterceptorIssueTest {
     }
 
     @Test
-    public void interceptor_is_called() {
+    void interceptor_is_called() {
         MockClient unirestMock = MockClient.register(this.unirestInstance);
 
         unirestMock

--- a/unirest-mocks/src/test/java/kong/tests/MultipleExpectsTest.java
+++ b/unirest-mocks/src/test/java/kong/tests/MultipleExpectsTest.java
@@ -31,9 +31,10 @@ import org.junit.jupiter.api.Test;
 import static kong.unirest.HttpMethod.GET;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MultipleExpectsTest extends Base {
+class MultipleExpectsTest extends Base {
+
     @Test
-    public void canDifferenciateBetweenExpectations() {
+    void canDifferenciateBetweenExpectations() {
         client.expect(GET, path).header("monster", "oscar").header("fruit", "apple");
         client.expect(GET, path).header("monster", "oscar");
 
@@ -47,7 +48,7 @@ public class MultipleExpectsTest extends Base {
     }
 
     @Test
-    public void willPickTheBestMatchingExpectation() {
+    void willPickTheBestMatchingExpectation() {
         client.expect(GET, path)
                 .header("monster", "grover")
                 .header("fruit", "apples");
@@ -67,7 +68,7 @@ public class MultipleExpectsTest extends Base {
     }
 
     @Test
-    public void willPickTheBestMatchingQueryExpectation() {
+    void willPickTheBestMatchingQueryExpectation() {
         client.expect(GET, path)
                 .queryString("monster", "grover");
 
@@ -90,7 +91,7 @@ public class MultipleExpectsTest extends Base {
     }
 
     @Test
-    public void whenDuplicateExpectsExistUseTheLastOne() {
+    void whenDuplicateExpectsExistUseTheLastOne() {
         client.expect(GET, path)
                 .queryString("monster", "grover")
                 .thenReturn("one");

--- a/unirest-mocks/src/test/java/kong/tests/RawResponseTest.java
+++ b/unirest-mocks/src/test/java/kong/tests/RawResponseTest.java
@@ -39,7 +39,8 @@ import java.io.InputStreamReader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class RawResponseTest extends Base {
+class RawResponseTest extends Base {
+
     @Test
     void getContentAsInputStream() {
         client.expect(HttpMethod.GET, path).thenReturn("hi");
@@ -108,7 +109,7 @@ public class RawResponseTest extends Base {
     void getSummary() {
         client.expect(HttpMethod.GET, path)
                 .thenReturn("hi")
-        .withStatus(HttpStatus.IM_A_TEAPOT, "Tip me over and pour me out");
+                .withStatus(HttpStatus.IM_A_TEAPOT, "Tip me over and pour me out");
 
         Unirest.get(path).thenConsume(raw -> {
             HttpResponseSummary i = raw.toSummary();
@@ -133,7 +134,7 @@ public class RawResponseTest extends Base {
     void getEncoding() {
         client.expect(HttpMethod.GET, path)
                 .thenReturn("hi")
-        .withHeader("Content-Encoding", "Klingon-32");
+                .withHeader("Content-Encoding", "Klingon-32");
 
         Unirest.get(path).thenConsume(raw -> {
             String encoding = raw.getEncoding();

--- a/unirest-mocks/src/test/java/kong/tests/RegistrationTest.java
+++ b/unirest-mocks/src/test/java/kong/tests/RegistrationTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class RegistrationTest {
+class RegistrationTest {
 
     @Test
     void canRegisterThePrimaryInstance() {

--- a/unirest/src/test/java/BehaviorTests/AsBytesTest.java
+++ b/unirest/src/test/java/BehaviorTests/AsBytesTest.java
@@ -26,17 +26,14 @@
 package BehaviorTests;
 
 import kong.unirest.JacksonObjectMapper;
-import kong.unirest.TestUtil;
 import kong.unirest.Unirest;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.ExecutionException;
-
-public class AsBytesTest extends BddTest {
+class AsBytesTest extends BddTest {
     JacksonObjectMapper om = new JacksonObjectMapper();
 
     @Test
-    public void getGetResultAsBytes() {
+    void getGetResultAsBytes() {
         byte[] content = Unirest.get(MockServer.GET)
                                 .asBytes()
                                 .getBody();
@@ -47,7 +44,7 @@ public class AsBytesTest extends BddTest {
     }
 
     @Test
-    public void getGetResultAsBytesAsync() throws Exception {
+    void getGetResultAsBytesAsync() throws Exception {
         byte[] content = Unirest.get(MockServer.GET)
                 .asBytesAsync()
                 .get()
@@ -59,7 +56,7 @@ public class AsBytesTest extends BddTest {
     }
 
     @Test
-    public void getGetResultAsBytesAsyncCallback() throws Exception {
+    void getGetResultAsBytesAsyncCallback() throws Exception {
         Unirest.get(MockServer.GET)
                 .queryString("fruit","apple")
                 .asBytesAsync(r -> {

--- a/unirest/src/test/java/BehaviorTests/AsEmptyTest.java
+++ b/unirest/src/test/java/BehaviorTests/AsEmptyTest.java
@@ -30,38 +30,39 @@ import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-
-public class AsEmptyTest extends BddTest {
+@SuppressWarnings("rawtypes")
+class AsEmptyTest extends BddTest {
 
     @Test
-    public void canDoAEmptyRequestThatDoesNotParseBodyAtAll() {
+    void canDoAEmptyRequestThatDoesNotParseBodyAtAll() {
         MockServer.addResponseHeader("Content-Type", "json");
         HttpResponse res = Unirest.get(MockServer.GET).asEmpty();
 
+        assertNull(res.getBody());
         assertEquals(200, res.getStatus());
-        assertEquals(null, res.getBody());
         assertEquals("json", res.getHeaders().getFirst("Content-Type"));
     }
 
     @Test
-    public void canDoEmptyAsync() throws Exception {
+    void canDoEmptyAsync() throws Exception {
         MockServer.addResponseHeader("Content-Type", "json");
         HttpResponse res = Unirest.get(MockServer.GET).asEmptyAsync().get();
 
+        assertNull(res.getBody());
         assertEquals(200, res.getStatus());
-        assertEquals(null, res.getBody());
         assertEquals("json", res.getHeaders().getFirst("Content-Type"));
     }
 
     @Test
-    public void canDoEmptyAsyncWithCallback() {
+    void canDoEmptyAsyncWithCallback() {
         MockServer.addResponseHeader("Content-Type", "json");
 
         Unirest.get(MockServer.GET)
                 .asEmptyAsync(res -> {
+                    assertNull(res.getBody());
                     assertEquals(200, res.getStatus());
-                    assertEquals(null, res.getBody());
                     assertEquals("json", res.getHeaders().getFirst("Content-Type"));
                     asyncSuccess();
                 });

--- a/unirest/src/test/java/BehaviorTests/AsFileTest.java
+++ b/unirest/src/test/java/BehaviorTests/AsFileTest.java
@@ -33,26 +33,29 @@ import kong.unirest.TestUtil;
 import kong.unirest.Unirest;
 
 import java.io.File;
-import java.nio.file.*;
-import java.util.concurrent.ExecutionException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AsFileTest extends BddTest {
+class AsFileTest extends BddTest {
 
-    private Path test = Paths.get("results.json");
-    private JacksonObjectMapper om = new JacksonObjectMapper();
+    private final Path test = Paths.get("results.json");
+    private final JacksonObjectMapper om = new JacksonObjectMapper();
 
     @Override @AfterEach
     public void tearDown() {
         try {
             Files.delete(test);
-        } catch (Exception e) { }
+        } catch (Exception ignored) { }
     }
 
     @Test
-    public void canSaveContentsIntoFile() {
+    void canSaveContentsIntoFile() {
         File result = Unirest.get(MockServer.GET)
                 .queryString("talking","heads")
                 .queryString("param3", "こんにちは")
@@ -68,7 +71,7 @@ public class AsFileTest extends BddTest {
     }
 
     @Test
-    public void canSaveContentsIntoFileAsync() throws Exception {
+    void canSaveContentsIntoFileAsync() throws Exception {
         File result = Unirest.get(MockServer.GET)
                 .queryString("talking","heads")
                 .queryString("param3", "こんにちは")
@@ -85,7 +88,7 @@ public class AsFileTest extends BddTest {
     }
 
     @Test
-    public void canSaveContentsIntoFileAsyncWithCallback() throws Exception {
+    void canSaveContentsIntoFileAsyncWithCallback() throws Exception {
         Unirest.get(MockServer.GET)
                 .queryString("talking","heads")
                 .queryString("param3", "こんにちは")
@@ -102,7 +105,7 @@ public class AsFileTest extends BddTest {
     }
 
     @Test
-    public void canDownloadABinaryFile() throws Exception {
+    void canDownloadABinaryFile() throws Exception {
         File f1 = TestUtil.rezFile("/spidey.jpg");
 
         File f2 = Unirest.get(MockServer.BINARYFILE)

--- a/unirest/src/test/java/BehaviorTests/AsGenericTypeTest.java
+++ b/unirest/src/test/java/BehaviorTests/AsGenericTypeTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AsGenericTypeTest extends BddTest {
+class AsGenericTypeTest extends BddTest {
 
     private final List<Foo> foos = Arrays.asList(
             new Foo("foo"),
@@ -45,7 +45,7 @@ public class AsGenericTypeTest extends BddTest {
     );
 
     @Test
-    public void canGetAListOfObjects() {
+    void canGetAListOfObjects() {
         MockServer.setJsonAsResponse(foos);
 
         List<Foo> foos = Unirest.get(MockServer.GET)
@@ -56,7 +56,7 @@ public class AsGenericTypeTest extends BddTest {
     }
 
     @Test
-    public void canGetAListOfObjectsAsync() throws ExecutionException, InterruptedException {
+    void canGetAListOfObjectsAsync() throws ExecutionException, InterruptedException {
         MockServer.setJsonAsResponse(foos);
 
         List<Foo> foos = Unirest.get(MockServer.GET)
@@ -68,7 +68,7 @@ public class AsGenericTypeTest extends BddTest {
     }
 
     @Test
-    public void canGetAListOfObjectsAsyncWithCallback()  {
+    void canGetAListOfObjectsAsyncWithCallback()  {
         MockServer.setJsonAsResponse(foos);
 
         Unirest.get(MockServer.GET)
@@ -83,7 +83,7 @@ public class AsGenericTypeTest extends BddTest {
     }
 
     @Test
-    public void soManyLayersOfGenerics() {
+    void soManyLayersOfGenerics() {
         MockServer.setJsonAsResponse(new WeirdType<>(foos, "hey"));
 
         WeirdType<List<Foo>> foos = Unirest.get(MockServer.GET)
@@ -95,7 +95,7 @@ public class AsGenericTypeTest extends BddTest {
     }
 
     @Test
-    public void itAlsoWorksWithGson() {
+    void itAlsoWorksWithGson() {
         Unirest.config().setObjectMapper(new JsonObjectMapper());
 
         MockServer.setJsonAsResponse(new WeirdType<>(foos, "hey"));

--- a/unirest/src/test/java/BehaviorTests/AsJsonTest.java
+++ b/unirest/src/test/java/BehaviorTests/AsJsonTest.java
@@ -32,13 +32,12 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class AsJsonTest extends BddTest {
+class AsJsonTest extends BddTest {
 
     @Test
-    public void whenNoBodyIsReturned() {
+    void whenNoBodyIsReturned() {
         HttpResponse<JsonNode> i = Unirest.get(MockServer.NOBODY).asJson();
 
         assertEquals(HttpStatus.OK, i.getStatus());
@@ -46,7 +45,7 @@ public class AsJsonTest extends BddTest {
     }
 
     @Test
-    public void toStringAObject() {
+    void toStringAObject() {
         MockServer.setStringResponse(new JSONObject().put("f", 1).put("a", Arrays.asList(2, 3, 4)).toString());
         HttpResponse<JsonNode> i = Unirest.get(MockServer.GET).asJson();
 
@@ -54,7 +53,7 @@ public class AsJsonTest extends BddTest {
     }
 
     @Test
-    public void toPrettyStringAObject() {
+    void toPrettyStringAObject() {
         MockServer.setStringResponse(new JSONObject().put("f", 1).put("a", Arrays.asList(2, 3, 4)).toString());
         HttpResponse<JsonNode> i = Unirest.get(MockServer.GET).asJson();
 
@@ -69,7 +68,7 @@ public class AsJsonTest extends BddTest {
     }
 
     @Test
-    public void canGetBinaryResponse() {
+    void canGetBinaryResponse() {
         HttpResponse<JsonNode> i = Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asJson();
@@ -78,7 +77,7 @@ public class AsJsonTest extends BddTest {
     }
 
     @Test
-    public void canGetBinaryResponseAsync() throws Exception {
+    void canGetBinaryResponseAsync() throws Exception {
         CompletableFuture<HttpResponse<JsonNode>> r = Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asJsonAsync();
@@ -87,7 +86,7 @@ public class AsJsonTest extends BddTest {
     }
 
     @Test
-    public void canGetBinaryResponseAsyncWithCallback() {
+    void canGetBinaryResponseAsyncWithCallback() {
         Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asJsonAsync(r -> {
@@ -99,11 +98,12 @@ public class AsJsonTest extends BddTest {
     }
 
     @Test
-    public void failureToReturnValidJsonWillResultInAnEmptyNode() {
+    void failureToReturnValidJsonWillResultInAnEmptyNode() {
         HttpResponse<JsonNode> response = Unirest.get(MockServer.INVALID_REQUEST).asJson();
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
         assertNull(response.getBody());
+        assertTrue(response.getParsingError().isPresent());
         UnirestParsingException ex = response.getParsingError().get();
         assertEquals("You did something bad", ex.getOriginalBody());
         assertEquals("kong.unirest.json.JSONException: Invalid JSON",
@@ -112,12 +112,12 @@ public class AsJsonTest extends BddTest {
     }
 
     @Test
-    public void failureToReturnValidJsonWillResultInAnEmptyNodeAsync() {
+    void failureToReturnValidJsonWillResultInAnEmptyNodeAsync() {
         Unirest.get(MockServer.INVALID_REQUEST)
                 .asJsonAsync(new MockCallback<>(this, response -> {
                     assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
                     assertNull(response.getBody());
-                    assertEquals(null, response.getBody());
+                    assertTrue(response.getParsingError().isPresent());
                     assertEquals("kong.unirest.json.JSONException: Invalid JSON",
                             response.getParsingError().get().getMessage());
 

--- a/unirest/src/test/java/BehaviorTests/AsObjectTest.java
+++ b/unirest/src/test/java/BehaviorTests/AsObjectTest.java
@@ -38,16 +38,16 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class AsObjectTest extends BddTest {
+class AsObjectTest extends BddTest {
 
     @Test
-    public void basicJsonObjectMapperIsTheDefault() {
+    void basicJsonObjectMapperIsTheDefault() {
         Unirest.config().shutDown(true);
         assertThat(Unirest.config().getObjectMapper(), instanceOf(JsonObjectMapper.class));
     }
 
     @Test
-    public void basicJsonObjectMapperIsGoodEnough() {
+    void basicJsonObjectMapperIsGoodEnough() {
         Unirest.config().shutDown(true);
         MockServer.setJsonAsResponse(new Foo("bar"));
 
@@ -59,7 +59,7 @@ public class AsObjectTest extends BddTest {
     }
 
     @Test
-    public void whenNoBodyIsReturned() {
+    void whenNoBodyIsReturned() {
         HttpResponse<RequestCapture> i = Unirest.get(MockServer.NOBODY).asObject(RequestCapture.class);
 
         assertEquals(200, i.getStatus());
@@ -67,7 +67,7 @@ public class AsObjectTest extends BddTest {
     }
 
     @Test
-    public void canGetObjectResponse() {
+    void canGetObjectResponse() {
          Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asObject(RequestCapture.class)
@@ -76,7 +76,7 @@ public class AsObjectTest extends BddTest {
     }
 
     @Test
-    public void canGetObjectResponseAsync() throws Exception {
+    void canGetObjectResponseAsync() throws Exception {
         Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asObjectAsync(RequestCapture.class)
@@ -86,7 +86,7 @@ public class AsObjectTest extends BddTest {
     }
 
     @Test
-    public void canGetObjectResponseAsyncWithCallback() {
+    void canGetObjectResponseAsyncWithCallback() {
         Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asObjectAsync(RequestCapture.class, r -> {
@@ -99,7 +99,7 @@ public class AsObjectTest extends BddTest {
     }
 
     @Test
-    public void canPassAnObjectMapperAsPartOfARequest(){
+    void canPassAnObjectMapperAsPartOfARequest(){
         Unirest.config().setObjectMapper(null);
 
         TestingMapper mapper = new TestingMapper();
@@ -128,7 +128,7 @@ public class AsObjectTest extends BddTest {
                 .body(new Foo("Orange"))
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserBody("{\"bar\":\"Orange\"}");
+                .assertBody("{\"bar\":\"Orange\"}");
     }
 
     @Test
@@ -152,7 +152,7 @@ public class AsObjectTest extends BddTest {
     }
 
     @Test
-    public void ifTheObjectMapperFailsReturnEmptyAndAddToParsingError() {
+    void ifTheObjectMapperFailsReturnEmptyAndAddToParsingError() {
         HttpResponse<RequestCapture> request = Unirest.get(MockServer.INVALID_REQUEST)
                 .asObject(RequestCapture.class);
 
@@ -165,7 +165,7 @@ public class AsObjectTest extends BddTest {
     }
 
     @Test
-    public void ifTheObjectMapperFailsReturnEmptyAndAddToParsingErrorObGenericTypes() {
+    void ifTheObjectMapperFailsReturnEmptyAndAddToParsingErrorObGenericTypes() {
         HttpResponse<RequestCapture> request = Unirest.get(MockServer.INVALID_REQUEST)
                 .asObject(new GenericType<RequestCapture>() {});
 
@@ -177,7 +177,7 @@ public class AsObjectTest extends BddTest {
     }
 
     @Test
-    public void unirestExceptionsAreAlsoParseExceptions() {
+    void unirestExceptionsAreAlsoParseExceptions() {
         HttpResponse<RequestCapture> request = Unirest.get(MockServer.INVALID_REQUEST)
                 .asObject(new GenericType<RequestCapture>() {});
 
@@ -189,7 +189,7 @@ public class AsObjectTest extends BddTest {
     }
 
     @Test
-    public void canSetObjectMapperToFailOnUnknown() {
+    void canSetObjectMapperToFailOnUnknown() {
         com.fasterxml.jackson.databind.ObjectMapper jack = new com.fasterxml.jackson.databind.ObjectMapper();
         jack.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 

--- a/unirest/src/test/java/BehaviorTests/AsStringTest.java
+++ b/unirest/src/test/java/BehaviorTests/AsStringTest.java
@@ -34,10 +34,10 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AsStringTest extends BddTest {
+class AsStringTest extends BddTest {
 
     @Test
-    public void whenNoBodyIsReturned() {
+    void whenNoBodyIsReturned() {
         HttpResponse<String> i = Unirest.get(MockServer.NOBODY).asString();
 
         assertEquals(200, i.getStatus());
@@ -45,7 +45,7 @@ public class AsStringTest extends BddTest {
     }
 
     @Test
-    public void canParseGzippedStringResponse() {
+    void canParseGzippedStringResponse() {
         HttpResponse<String> i = Unirest.get(MockServer.GZIP)
                 .queryString("foo", "bar")
                 .asString();
@@ -56,7 +56,7 @@ public class AsStringTest extends BddTest {
     }
 
     @Test
-    public void canParseGzippedResponseAsync() throws Exception {
+    void canParseGzippedResponseAsync() throws Exception {
         HttpResponse<String> i = Unirest.get(MockServer.GZIP)
                 .queryString("foo", "bar")
                 .asStringAsync().get();
@@ -67,7 +67,7 @@ public class AsStringTest extends BddTest {
     }
 
     @Test
-    public void canGetBinaryResponse() {
+    void canGetBinaryResponse() {
         HttpResponse<String> i = Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asString();
@@ -77,7 +77,7 @@ public class AsStringTest extends BddTest {
     }
 
     @Test
-    public void canGetBinaryResponseAsync() throws Exception {
+    void canGetBinaryResponseAsync() throws Exception {
         CompletableFuture<HttpResponse<String>> r = Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asStringAsync();
@@ -87,7 +87,7 @@ public class AsStringTest extends BddTest {
     }
 
     @Test
-    public void canGetBinaryResponseAsyncWithCallback() {
+    void canGetBinaryResponseAsyncWithCallback() {
         Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asStringAsync(r -> {
@@ -100,14 +100,14 @@ public class AsStringTest extends BddTest {
     }
 
     @Test
-    public void unicodeResponse() {
+    void unicodeResponse() {
         MockServer.setStringResponse("ěščřžýáíé");
 
         assertEquals("ěščřžýáíé", Unirest.get(MockServer.GET).asString().getBody());
     }
 
     @Test
-    public void unicodeResponseAsync() throws Exception {
+    void unicodeResponseAsync() throws Exception {
         MockServer.setStringResponse("ěščřžýáíé");
 
         Unirest.get(MockServer.GET)
@@ -120,7 +120,7 @@ public class AsStringTest extends BddTest {
     }
 
     @Test
-    public void canSetExpectedCharsetOfResponse() {
+    void canSetExpectedCharsetOfResponse() {
         HttpResponse<String> response = Unirest.get(MockServer.WINDOWS_LATIN_1_FILE)
                 .responseEncoding("windows-1250")
                 .asString();
@@ -130,7 +130,7 @@ public class AsStringTest extends BddTest {
     }
 
     @Test
-    public void canSetDefaultCharsetOfResponse() {
+    void canSetDefaultCharsetOfResponse() {
         Unirest.config().setDefaultResponseEncoding("windows-1250");
 
         HttpResponse<String> response = Unirest.get(MockServer.WINDOWS_LATIN_1_FILE)

--- a/unirest/src/test/java/BehaviorTests/BaseUrlTest.java
+++ b/unirest/src/test/java/BehaviorTests/BaseUrlTest.java
@@ -28,7 +28,7 @@ package BehaviorTests;
 import kong.unirest.Unirest;
 import org.junit.jupiter.api.Test;
 
-public class BaseUrlTest extends BddTest {
+class BaseUrlTest extends BddTest {
 
     @Test
     void canConfigureADefaultBaseUrl() {

--- a/unirest/src/test/java/BehaviorTests/BddTest.java
+++ b/unirest/src/test/java/BehaviorTests/BddTest.java
@@ -34,9 +34,8 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-
 public class BddTest {
-    private static JacksonObjectMapper objectMapper = new JacksonObjectMapper();
+    private static final JacksonObjectMapper objectMapper = new JacksonObjectMapper();
     private CountDownLatch lock;
     private boolean status;
     private String fail;

--- a/unirest/src/test/java/BehaviorTests/CachingAlternativeTest.java
+++ b/unirest/src/test/java/BehaviorTests/CachingAlternativeTest.java
@@ -38,7 +38,7 @@ import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class CachingAlternativeTest extends BddTest {
+class CachingAlternativeTest extends BddTest {
 
     @Test
     void canSupplyCustomCache() {

--- a/unirest/src/test/java/BehaviorTests/CachingTest.java
+++ b/unirest/src/test/java/BehaviorTests/CachingTest.java
@@ -37,7 +37,7 @@ import static com.google.common.collect.ImmutableMap.of;
 import static kong.unirest.Cache.builder;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class CachingTest extends BddTest {
+class CachingTest extends BddTest {
 
     @Test
     void doesNotCacheByDefault() {

--- a/unirest/src/test/java/BehaviorTests/CallbackFutureTest.java
+++ b/unirest/src/test/java/BehaviorTests/CallbackFutureTest.java
@@ -34,11 +34,10 @@ import org.junit.jupiter.api.Timeout;
 
 import static kong.unirest.MockCallback.json;
 
-public class CallbackFutureTest extends BddTest {
-
+class CallbackFutureTest extends BddTest {
 
     @Test @Timeout(5)
-    public void onSuccess() throws Exception {
+    void onSuccess() throws Exception {
         Unirest.get(MockServer.GET)
                 .queryString("Snazzy", "Shoes")
                 .asJsonAsync()
@@ -51,7 +50,7 @@ public class CallbackFutureTest extends BddTest {
     }
 
     @Test @Timeout(5)
-    public void onSuccessSupplyCallback() throws Exception {
+    void onSuccessSupplyCallback() throws Exception {
         Unirest.get(MockServer.GET)
                 .queryString("Snazzy", "Shoes")
                 .asJsonAsync(new NoopCallback<>())
@@ -64,7 +63,7 @@ public class CallbackFutureTest extends BddTest {
     }
 
     @Test @Timeout(5) @Disabled
-    public void onFailure() throws Exception {
+    void onFailure() throws Exception {
         Unirest.get("http://localhost:0000")
                 .asJsonAsync(json(this))
                 .isCompletedExceptionally();

--- a/unirest/src/test/java/BehaviorTests/CertificateTests.java
+++ b/unirest/src/test/java/BehaviorTests/CertificateTests.java
@@ -163,7 +163,7 @@ class CertificateTests extends BddTest {
     }
 
     @Test
-    void canSetHoestNameVerifyer() throws Exception {
+    void canSetHoestNameVerifyer() {
         Unirest.config().hostnameVerifier(new NoopHostnameVerifier());
 
         int response = Unirest.get("https://badssl.com/").asEmpty().getStatus();

--- a/unirest/src/test/java/BehaviorTests/ConsumerTest.java
+++ b/unirest/src/test/java/BehaviorTests/ConsumerTest.java
@@ -40,7 +40,7 @@ import java.nio.file.Paths;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ConsumerTest extends BddTest {
+class ConsumerTest extends BddTest {
 
     Path test = Paths.get("1.jpeg");
     private int status;
@@ -60,7 +60,7 @@ public class ConsumerTest extends BddTest {
     }
 
     @Test
-    public void canSimplyConsumeAResponse() {
+    void canSimplyConsumeAResponse() {
         Unirest.get(MockServer.GET)
                 .thenConsume(r -> status = r.getStatus());
 
@@ -68,7 +68,7 @@ public class ConsumerTest extends BddTest {
     }
 
     @Test
-    public void downloadAFileAsync() throws Exception {
+    void downloadAFileAsync() {
         Unirest.get(MockServer.BINARYFILE)
                 .thenConsumeAsync(r -> {
                     try {
@@ -90,7 +90,7 @@ public class ConsumerTest extends BddTest {
     }
 
     @Test
-    public void downloadAFile() throws Exception {
+    void downloadAFile() {
         Unirest.get(MockServer.BINARYFILE)
                 .thenConsume(r -> {
                     try {
@@ -108,7 +108,7 @@ public class ConsumerTest extends BddTest {
     }
 
     @Test
-    public void canSimplyConsumeAResponseAsync() {
+    void canSimplyConsumeAResponseAsync() {
         Unirest.get(MockServer.GET)
                 .thenConsumeAsync(r -> status = r.getStatus());
 

--- a/unirest/src/test/java/BehaviorTests/CookieTest.java
+++ b/unirest/src/test/java/BehaviorTests/CookieTest.java
@@ -26,21 +26,19 @@
 package BehaviorTests;
 
 import kong.unirest.Cookie;
-import kong.unirest.Cookies;
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
 import org.apache.http.client.config.CookieSpecs;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class CookieTest extends BddTest {
+class CookieTest extends BddTest {
 
     @Test
-    public void canSetCookie(){
+    void canSetCookie(){
         Unirest.get(MockServer.GET)
                 .cookie("flavor","snickerdoodle")
                 .cookie("size", "large")
@@ -51,7 +49,7 @@ public class CookieTest extends BddTest {
     }
 
     @Test
-    public void canSetAsCookie(){
+    void canSetAsCookie(){
         Unirest.get(MockServer.GET)
                 .cookie(new Cookie("flavor", "snickerdoodle"))
                 .cookie(new Cookie("size", "large"))
@@ -62,7 +60,7 @@ public class CookieTest extends BddTest {
     }
 
     @Test
-    public void canSetAsCookieCollection(){
+    void canSetAsCookieCollection(){
         Unirest.get(MockServer.GET)
                 .cookie(Arrays.asList(
                         new Cookie("flavor", "snickerdoodle"),
@@ -76,7 +74,7 @@ public class CookieTest extends BddTest {
 
 
     @Test
-    public void willManageCookiesByDefault() {
+    void willManageCookiesByDefault() {
         MockServer.expectCookie("JSESSIONID", "ABC123");
         Unirest.get(MockServer.GET).asEmpty();
         Unirest.get(MockServer.GET)
@@ -86,7 +84,7 @@ public class CookieTest extends BddTest {
     }
 
     @Test
-    public void canGetCookiesFromTheResponse() {
+    void canGetCookiesFromTheResponse() {
         MockServer.expectCookie("JSESSIONID", "ABC123");
         MockServer.expectCookie("color", "ruby");
 
@@ -97,7 +95,7 @@ public class CookieTest extends BddTest {
     }
 
     @Test
-    public void canGetUnicode() {
+    void canGetUnicode() {
         MockServer.expectCookie("nepali", "फनकी");
 
         HttpResponse response = Unirest.get(MockServer.GET).asEmpty();
@@ -106,7 +104,7 @@ public class CookieTest extends BddTest {
     }
 
     @Test
-    public void canGetValuesWithBadCharacters() {
+    void canGetValuesWithBadCharacters() {
         MockServer.expectCookie("odd", "1=2;3=4");
 
         HttpResponse response = Unirest.get(MockServer.GET).asEmpty();
@@ -115,7 +113,7 @@ public class CookieTest extends BddTest {
     }
 
     @Test
-    public void complicatedCookies(){
+    void complicatedCookies(){
         javax.servlet.http.Cookie cookie = new javax.servlet.http.Cookie("color", "blue");
         cookie.setDomain("localhost");
         cookie.setPath("/get");
@@ -137,7 +135,7 @@ public class CookieTest extends BddTest {
     }
 
     @Test
-    public void canTurnOffCookieManagement() {
+    void canTurnOffCookieManagement() {
         Unirest.config().enableCookieManagement(false);
         MockServer.expectCookie("JSESSIONID", "ABC123");
         Unirest.get(MockServer.GET).asEmpty();
@@ -148,7 +146,7 @@ public class CookieTest extends BddTest {
     }
 
     @Test
-    public void canSetCookieSpec() {
+    void canSetCookieSpec() {
         Unirest.config().cookieSpec(CookieSpecs.IGNORE_COOKIES);
 
         MockServer.expectCookie("JSESSIONID", "ABC123");
@@ -160,7 +158,7 @@ public class CookieTest extends BddTest {
     }
 
     @Test
-    public void doubleQuotedValues() {
+    void doubleQuotedValues() {
         MockServer.expectCookie(new javax.servlet.http.Cookie("foo", "\"bar\""));
 
         HttpResponse<RequestCapture> res = Unirest.get(MockServer.GET)

--- a/unirest/src/test/java/BehaviorTests/CustomClientTest.java
+++ b/unirest/src/test/java/BehaviorTests/CustomClientTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CustomClientTest extends BddTest {
+class CustomClientTest extends BddTest {
 
     private final String url = "http://localhost/getme";
     boolean requestConfigUsed = false;
@@ -55,7 +55,7 @@ public class CustomClientTest extends BddTest {
     }
 
     @Test
-    public void settingACustomClient() {
+    void settingACustomClient() {
         HttpClientMock client = getMockClient();
 
         Unirest.config().httpClient(client);
@@ -64,7 +64,7 @@ public class CustomClientTest extends BddTest {
     }
 
     @Test
-    public void settingACustomClientWithBuilder() {
+    void settingACustomClientWithBuilder() {
         HttpClientMock client = getMockClient();
 
         Unirest.config().httpClient(ApacheClient.builder(client)
@@ -81,7 +81,7 @@ public class CustomClientTest extends BddTest {
     }
 
     @Test
-    public void canSetACustomAsyncClientWithBuilder() throws Exception {
+    void canSetACustomAsyncClientWithBuilder() throws Exception {
         try(CloseableHttpAsyncClient client = HttpAsyncClientBuilder.create().build()) {
             client.start();
 

--- a/unirest/src/test/java/BehaviorTests/CustomObjectMapperTest.java
+++ b/unirest/src/test/java/BehaviorTests/CustomObjectMapperTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 
-public class CustomObjectMapperTest extends BddTest {
+class CustomObjectMapperTest extends BddTest {
 
     private JsonObjectMapper customOm;
 

--- a/unirest/src/test/java/BehaviorTests/DefectTest.java
+++ b/unirest/src/test/java/BehaviorTests/DefectTest.java
@@ -39,10 +39,10 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class DefectTest extends BddTest {
+class DefectTest extends BddTest {
 
     @Test
-    public void hashOnLinksDoNotMessUpUri() {
+    void hashOnLinksDoNotMessUpUri() {
         Unirest.get(MockServer.GET + "?a=1&b=2#some_location")
                 .asObject(RequestCapture.class)
                 .getBody()
@@ -51,7 +51,7 @@ public class DefectTest extends BddTest {
     }
 
     @Test
-    public void nullAndObjectValuesInMap() {
+    void nullAndObjectValuesInMap() {
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("foo", null);
         queryParams.put("baz", "qux");
@@ -67,7 +67,7 @@ public class DefectTest extends BddTest {
 
 
     @Test
-    public void issue_41_IllegalThreadStateExceptionUnderHighLoad() throws IOException {
+    void issue_41_IllegalThreadStateExceptionUnderHighLoad() throws IOException {
         Unirest.get(MockServer.GET).asStringAsync();
 
         HttpAsyncClient first = Unirest.config().getAsyncClient().getClient();
@@ -87,7 +87,7 @@ public class DefectTest extends BddTest {
     }
 
     @Test @Disabled
-    public void trySomeoneElsesGZip() throws Exception {
+    void trySomeoneElsesGZip() throws Exception {
         JSONObject body = Unirest.get("http://httpbin.org/gzip")
                 .asJsonAsync().get().getBody().getObject();
 

--- a/unirest/src/test/java/BehaviorTests/DownloadProgressTest.java
+++ b/unirest/src/test/java/BehaviorTests/DownloadProgressTest.java
@@ -34,7 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public class DownloadProgressTest extends BddTest {
+class DownloadProgressTest extends BddTest {
     @TempDir
     File targeFolder;
 
@@ -48,7 +48,7 @@ public class DownloadProgressTest extends BddTest {
     }
 
     @Test
-    public void canAddUploadProgress() {
+    void canAddUploadProgress() {
         Unirest.get(MockServer.BINARYFILE)
                 .downloadMonitor(monitor)
                 .asFile(targeFolder.getPath() + "/spidey.jpg");
@@ -57,7 +57,7 @@ public class DownloadProgressTest extends BddTest {
     }
 
     @Test
-    public void canAddUploadProgressAsync() throws Exception {
+    void canAddUploadProgressAsync() throws Exception {
         Unirest.get(MockServer.BINARYFILE)
                 .downloadMonitor(monitor)
                 .asFileAsync(targeFolder.getPath() + "/spidey.jpg")

--- a/unirest/src/test/java/BehaviorTests/ErrorParsingTest.java
+++ b/unirest/src/test/java/BehaviorTests/ErrorParsingTest.java
@@ -36,11 +36,11 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-public class ErrorParsingTest extends BddTest {
+class ErrorParsingTest extends BddTest {
     private boolean errorCalled;
 
     @Test
-    public void parsingAnAlternativeErrorObject() {
+    void parsingAnAlternativeErrorObject() {
         MockServer.setJsonAsResponse(new ErrorThing("boom!"));
 
         ErrorThing e = Unirest.get(MockServer.ERROR_RESPONSE)
@@ -51,7 +51,7 @@ public class ErrorParsingTest extends BddTest {
     }
 
     @Test
-    public void mapTheErrorToAString() {
+    void mapTheErrorToAString() {
         MockServer.setJsonAsResponse(new ErrorThing("boom!"));
 
         String e = Unirest.get(MockServer.ERROR_RESPONSE)
@@ -62,7 +62,7 @@ public class ErrorParsingTest extends BddTest {
     }
 
     @Test
-    public void parsingAnAlternativeErrorObject_StringBody() {
+    void parsingAnAlternativeErrorObject_StringBody() {
         MockServer.setJsonAsResponse(new ErrorThing("boom!"));
 
         ErrorThing e = Unirest.get(MockServer.ERROR_RESPONSE)
@@ -73,7 +73,7 @@ public class ErrorParsingTest extends BddTest {
     }
 
     @Test
-    public void parsingAnAlternativeErrorObject_JsonBody() {
+    void parsingAnAlternativeErrorObject_JsonBody() {
         MockServer.setJsonAsResponse(new ErrorThing("boom!"));
 
         ErrorThing e = Unirest.get(MockServer.ERROR_RESPONSE)
@@ -84,7 +84,7 @@ public class ErrorParsingTest extends BddTest {
     }
 
     @Test
-    public void ifNoErrorThenGetTheRegularBody() {
+    void ifNoErrorThenGetTheRegularBody() {
         ErrorThing error = Unirest.get(MockServer.GET)
                 .asObject(RequestCapture.class)
                 .mapError(ErrorThing.class);
@@ -93,7 +93,7 @@ public class ErrorParsingTest extends BddTest {
     }
 
     @Test
-    public void failsIfErrorResponseCantBeMapped() {
+    void failsIfErrorResponseCantBeMapped() {
         JacksonObjectMapper om = new JacksonObjectMapper();
         om.om.configure(JsonGenerator.Feature.IGNORE_UNKNOWN, false);
         om.om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
@@ -106,12 +106,12 @@ public class ErrorParsingTest extends BddTest {
 
         NotTheError error = request.mapError(NotTheError.class);
 
-        assertEquals(null, error.merp);
+        assertNull(error.merp);
         assertEquals("{\"message\":\"boom!\"}", request.getParsingError().get().getOriginalBody());
     }
 
     @Test
-    public void mapTheErrorWithAFunction() {
+    void mapTheErrorWithAFunction() {
         MockServer.setJsonAsResponse(new ErrorThing("boom!"));
 
         errorCalled = false;
@@ -127,7 +127,7 @@ public class ErrorParsingTest extends BddTest {
     }
 
     @Test
-    public void willKeepBodyAroundOnFailures_WhenJacksonIsPassive() {
+    void willKeepBodyAroundOnFailures_WhenJacksonIsPassive() {
         MockServer.setJsonAsResponse(new ErrorThing("boom!"));
 
         Unirest.get(MockServer.ERROR_RESPONSE)

--- a/unirest/src/test/java/BehaviorTests/FormPostingTest.java
+++ b/unirest/src/test/java/BehaviorTests/FormPostingTest.java
@@ -36,10 +36,10 @@ import static java.util.Arrays.asList;
 import static kong.unirest.TestUtil.rezFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class FormPostingTest extends BddTest {
+class FormPostingTest extends BddTest {
 
     @Test
-    public void testFormFields() {
+    void testFormFields() {
         Unirest.post(MockServer.POST)
                 .header("accept", "application/json")
                 .field("param1", "value1")
@@ -52,7 +52,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void formPostAsync() {
+    void formPostAsync() {
         Unirest.post(MockServer.POST)
                 .header("accept", "application/json")
                 .field("param1", "value1")
@@ -68,7 +68,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void testAsyncCustomContentTypeAndFormParams() {
+    void testAsyncCustomContentTypeAndFormParams() {
         Unirest.post(MockServer.POST)
                 .header("accept", "application/json")
                 .header("Content-Type", "application/x-www-form-urlencoded")
@@ -84,7 +84,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void testPostArray() {
+    void testPostArray() {
         Unirest.post(MockServer.POST)
                 .field("name", "Mark")
                 .field("name", "Tom")
@@ -96,7 +96,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void testPostUTF8() {
+    void testPostUTF8() {
         Unirest.post(MockServer.POST)
                 .header("accept", "application/json")
                 .field("param3", "こんにちは")
@@ -107,7 +107,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void testPostCollection() {
+    void testPostCollection() {
         Unirest.post(MockServer.POST)
                 .field("name", asList("Mark", "Tom"))
                 .asObject(RequestCapture.class)
@@ -118,7 +118,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void nullMapDoesntBomb() {
+    void nullMapDoesntBomb() {
         Unirest.post(MockServer.POST)
                 .queryString("foo","bar")
                 .fields(null)
@@ -129,7 +129,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void testDelete() {
+    void testDelete() {
         Unirest.delete(MockServer.DELETE)
                 .field("name", "mark")
                 .field("foo", "bar")
@@ -141,7 +141,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void testChangingEncodingToForms(){
+    void testChangingEncodingToForms(){
         Unirest.post(MockServer.POST)
                 .charset(StandardCharsets.US_ASCII)
                 .field("foo", "bar")
@@ -153,7 +153,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void canNotIncludeCharset(){
+    void canNotIncludeCharset(){
         Unirest.post(MockServer.POST)
                 .noCharset()
                 .field("foo", "bar")
@@ -163,7 +163,7 @@ public class FormPostingTest extends BddTest {
     }
 
     @Test
-    public void testChangingEncodingAfterMovingToForm(){
+    void testChangingEncodingAfterMovingToForm(){
         Unirest.post(MockServer.POST)
                 .field("foo", "bar")
                 .charset(StandardCharsets.US_ASCII)

--- a/unirest/src/test/java/BehaviorTests/GZipTest.java
+++ b/unirest/src/test/java/BehaviorTests/GZipTest.java
@@ -32,9 +32,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class GZipTest extends BddTest {
+class GZipTest extends BddTest {
+
     @Test
-    public void emptyGzip() {
+    void emptyGzip() {
         HttpResponse<String> result = Unirest.post(MockServer.EMPTY_GZIP)
                 .asString();
         assertFalse(result.getParsingError().isPresent());
@@ -42,7 +43,7 @@ public class GZipTest extends BddTest {
     }
 
     @Test
-    public void testGzip() {
+    void testGzip() {
         HttpResponse<RequestCapture> resp = Unirest.get(MockServer.GZIP)
                 .queryString("zipme", "up")
                 .asObject(RequestCapture.class);
@@ -55,7 +56,7 @@ public class GZipTest extends BddTest {
     }
 
     @Test
-    public void testGzipAsync() throws Exception {
+    void testGzipAsync() throws Exception {
         HttpResponse<RequestCapture> resp = Unirest.get(MockServer.GZIP)
                 .queryString("zipme", "up")
                 .asObjectAsync(RequestCapture.class)
@@ -69,7 +70,7 @@ public class GZipTest extends BddTest {
     }
 
     @Test
-    public void canDisableGZip() throws Exception {
+    void canDisableGZip() throws Exception {
         Unirest.config().requestCompression(false);
 
         Unirest.get(MockServer.GET)

--- a/unirest/src/test/java/BehaviorTests/GenericMappingTest.java
+++ b/unirest/src/test/java/BehaviorTests/GenericMappingTest.java
@@ -31,9 +31,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class GenericMappingTest extends BddTest {
+class GenericMappingTest extends BddTest {
+
     @Test
-    public void canMapBody() {
+    void canMapBody() {
         MockServer.setStringResponse("123456");
 
         int body = Unirest.get(MockServer.GET).asString().mapBody(Integer::valueOf);
@@ -42,7 +43,7 @@ public class GenericMappingTest extends BddTest {
     }
 
     @Test
-    public void canMapTheEntireResponseIntoAnotherResponse() {
+    void canMapTheEntireResponseIntoAnotherResponse() {
         MockServer.setStringResponse("123456");
         MockServer.addResponseHeader("cheese","cheddar");
 

--- a/unirest/src/test/java/BehaviorTests/HeaderTest.java
+++ b/unirest/src/test/java/BehaviorTests/HeaderTest.java
@@ -36,11 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static kong.unirest.TestUtil.assertBasicAuth;
 import static kong.unirest.TestUtil.mapOf;
 
-public class HeaderTest extends BddTest {
+class HeaderTest extends BddTest {
+
     private String value = "one";
 
     @Test
-    public void contentLengthIsSetWithBodies() {
+    void contentLengthIsSetWithBodies() {
         Unirest.post(MockServer.POST)
                 .body("do do do do")
                 .asObject(RequestCapture.class)
@@ -49,7 +50,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void testHeadersOnGetRequests() {
+    void testHeadersOnGetRequests() {
         Unirest.get(MockServer.GET)
                 .header("user-agent", "hello-world")
                 .accept("application/cheese-wiz")
@@ -60,7 +61,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void testBasicAuth() {
+    void testBasicAuth() {
         Unirest.get(MockServer.GET)
                 .basicAuth("user", "password1!")
                 .asObject(RequestCapture.class)
@@ -70,7 +71,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void unicodeBasicAuth() {
+    void unicodeBasicAuth() {
         Unirest.get(MockServer.GET)
                 .basicAuth("こんにちは", "こんにちは")
                 .asObject(RequestCapture.class)
@@ -80,7 +81,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void testDefaultHeaders() {
+    void testDefaultHeaders() {
         Unirest.config().setDefaultHeader("X-Custom-Header", "hello");
         Unirest.config().setDefaultHeader("user-agent", "foobar");
 
@@ -103,7 +104,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void testCaseInsensitiveHeaders() {
+    void testCaseInsensitiveHeaders() {
         GetRequest request = Unirest.get(MockServer.GET)
                 .header("Name", "Marco");
 
@@ -126,7 +127,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void headersOnMultipart() {
+    void headersOnMultipart() {
         Unirest.post(MockServer.POST)
                 .field("one","a")
                 .accept("application/json")
@@ -143,7 +144,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void canPassHeadersAsMap() {
+    void canPassHeadersAsMap() {
         Unirest.post(MockServer.POST)
                 .headers(mapOf("one", "foo", "two", "bar", "three", null))
                 .asObject(RequestCapture.class)
@@ -154,7 +155,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void basicAuthOnPosts() {
+    void basicAuthOnPosts() {
         Unirest.post(MockServer.POST)
                 .basicAuth("user", "test")
                 .asObject(RequestCapture.class)
@@ -164,7 +165,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void canSetDefaultBasicAuth() {
+    void canSetDefaultBasicAuth() {
         Unirest.config().setDefaultBasicAuth("bob", "pass");
         Unirest.config().setDefaultBasicAuth("user", "test");
 
@@ -176,7 +177,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void canOverrideDefaultBasicAuth() {
+    void canOverrideDefaultBasicAuth() {
         Unirest.config().setDefaultBasicAuth("bob", "pass");
 
         Unirest.post(MockServer.POST)
@@ -194,7 +195,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void willNotCacheBasicAuth() {
+    void willNotCacheBasicAuth() {
         Unirest.get(MockServer.GET)
                 .basicAuth("george","guitar")
                 .asObject(RequestCapture.class)
@@ -214,7 +215,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void willNotCacheHeadersAccrossRequests() {
+    void willNotCacheHeadersAccrossRequests() {
         Unirest.get(MockServer.GET)
                 .header("foo", "bar")
                 .asObject(RequestCapture.class)
@@ -234,7 +235,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void doesNotCacheAcrossTypes(){
+    void doesNotCacheAcrossTypes(){
         Unirest.get(MockServer.GET)
                 .basicAuth("user1","pass1")
                 .asObject(RequestCapture.class)
@@ -249,7 +250,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test @Disabled
-    public void doesNotCacheAuthAcrossDomains(){
+    void doesNotCacheAuthAcrossDomains(){
         Unirest.get(MockServer.GET)
                 .basicAuth("user1","pass1")
                 .asObject(RequestCapture.class)
@@ -266,7 +267,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test //https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
-    public void canHaveTheSameHeaderAddedTwice() {
+    void canHaveTheSameHeaderAddedTwice() {
         Unirest.config().setDefaultHeader("x-fruit", "orange");
 
         Unirest.get(MockServer.GET)
@@ -279,7 +280,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void canReplaceAHeader() {
+    void canReplaceAHeader() {
         Unirest.config().setDefaultHeader("foo", "bar");
         Unirest.get(MockServer.GET)
                 .headerReplace("foo", "qux")
@@ -293,7 +294,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void setVsAddDefaultHeaders() {
+    void setVsAddDefaultHeaders() {
         Unirest.config().setDefaultHeader("foo", "bar")
                         .setDefaultHeader("foo", "qux")
                         .addDefaultHeader("fruit", "mango")
@@ -316,7 +317,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void canSetAHeaderAsASupplier() {
+    void canSetAHeaderAsASupplier() {
         Unirest.config().setDefaultHeader("trace", () -> value);
 
         Unirest.get(MockServer.GET)
@@ -333,7 +334,7 @@ public class HeaderTest extends BddTest {
     }
 
     @Test
-    public void nullTests() {
+    void nullTests() {
         Unirest.get(MockServer.GET)
                 .header("foo","bar")
                 .headers(null)

--- a/unirest/src/test/java/BehaviorTests/HostsHeaderTest.java
+++ b/unirest/src/test/java/BehaviorTests/HostsHeaderTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class HostsHeaderTest extends BddTest {
+class HostsHeaderTest extends BddTest {
 
     @Test
     void willHonorHostsHeaders() {

--- a/unirest/src/test/java/BehaviorTests/InterceptorTest.java
+++ b/unirest/src/test/java/BehaviorTests/InterceptorTest.java
@@ -46,10 +46,10 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class InterceptorTest extends BddTest {
+class InterceptorTest extends BddTest {
 
     private UniInterceptor interceptor;
-    private String  ioErrorMessage = "Something horrible happened";;
+    private final String ioErrorMessage = "Something horrible happened";;
 
     @BeforeEach
     public void setUp() {
@@ -58,7 +58,7 @@ public class InterceptorTest extends BddTest {
     }
 
     @Test
-    public void canAddInterceptor() {
+    void canAddInterceptor() {
         Unirest.config().interceptor(interceptor);
         Unirest.get(MockServer.GET).asObject(RequestCapture.class);
 
@@ -67,7 +67,7 @@ public class InterceptorTest extends BddTest {
     }
 
     @Test
-    public void canAddTwoInterceptor() {
+    void canAddTwoInterceptor() {
         Unirest.config().interceptor(interceptor);
         Unirest.config().interceptor(new UniInterceptor("fruit", "grapes"));
         Unirest.get(MockServer.GET).asObject(RequestCapture.class);
@@ -77,7 +77,7 @@ public class InterceptorTest extends BddTest {
     }
 
     @Test
-    public void canAddInterceptorToAsync() throws ExecutionException, InterruptedException {
+    void canAddInterceptorToAsync() throws ExecutionException, InterruptedException {
         Unirest.config().interceptor(interceptor);
 
         Unirest.get(MockServer.GET)
@@ -88,7 +88,7 @@ public class InterceptorTest extends BddTest {
     }
 
     @Test
-    public void totalFailure() throws Exception {
+    void totalFailure() throws Exception {
         Unirest.config().httpClient(getFailureClient()).interceptor(interceptor);
 
         TestUtil.assertException(() -> Unirest.get(MockServer.GET).asEmpty(),
@@ -97,7 +97,7 @@ public class InterceptorTest extends BddTest {
     }
 
     @Test
-    public void canReturnEmptyResultRatherThanThrow() throws Exception {
+    void canReturnEmptyResultRatherThanThrow() throws Exception {
         Unirest.config().httpClient(getFailureClient()).interceptor(interceptor);
         interceptor.failResponse = true;
 
@@ -108,7 +108,7 @@ public class InterceptorTest extends BddTest {
     }
 
     @Test
-    public void totalAsyncFailure() throws Exception {
+    void totalAsyncFailure() throws Exception {
         Unirest.config().addInterceptor((r, c) -> {
             throw new IOException(ioErrorMessage);
         }).interceptor(interceptor);
@@ -119,7 +119,7 @@ public class InterceptorTest extends BddTest {
     }
 
     @Test
-    public void totalAsyncFailure_Recovery() throws Exception {
+    void totalAsyncFailure_Recovery() throws Exception {
         interceptor.failResponse = true;
         Unirest.config().addInterceptor((r, c) -> {
             throw new IOException(ioErrorMessage);
@@ -139,7 +139,7 @@ public class InterceptorTest extends BddTest {
     }
 
     @Test @Deprecated
-    public void canAddApacheInterceptor() {
+    void canAddApacheInterceptor() {
         Unirest.config().addInterceptor(new TestInterceptor());
 
         Unirest.get(MockServer.GET)
@@ -149,7 +149,7 @@ public class InterceptorTest extends BddTest {
     }
 
     @Test @Deprecated
-    public void canAddApacheInterceptorToAsync() throws ExecutionException, InterruptedException {
+    void canAddApacheInterceptorToAsync() throws ExecutionException, InterruptedException {
         Unirest.config().addInterceptor(new TestInterceptor());
 
         Unirest.get(MockServer.GET)

--- a/unirest/src/test/java/BehaviorTests/JankyProxy.java
+++ b/unirest/src/test/java/BehaviorTests/JankyProxy.java
@@ -113,7 +113,7 @@ class ThreadProxy extends Thread {
                         outToServer.flush();
                         wasUsedForClientToServer = true;
                     }
-                } catch (IOException e) {
+                } catch (IOException ignored) {
                 }
                 try {
                     outToServer.close();

--- a/unirest/src/test/java/BehaviorTests/JsonPatchTest.java
+++ b/unirest/src/test/java/BehaviorTests/JsonPatchTest.java
@@ -33,14 +33,12 @@ import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import kong.unirest.TestUtil;
 
-import java.io.IOException;
-
 import static kong.unirest.JsonPatchOperation.*;
 
-public class JsonPatchTest extends BddTest {
+class JsonPatchTest extends BddTest {
 
     @Test
-    public void canAddThings() {
+    void canAddThings() {
         Unirest.jsonPatch(MockServer.PATCH)
                 .add("/some/path", "a value")
                 .add("/another/path", 42)
@@ -54,7 +52,7 @@ public class JsonPatchTest extends BddTest {
     }
 
     @Test
-    public void canRemoveThings() {
+    void canRemoveThings() {
         Unirest.jsonPatch(MockServer.PATCH)
                 .remove("/some/path")
                 .remove("/another/path")
@@ -68,7 +66,7 @@ public class JsonPatchTest extends BddTest {
     }
 
     @Test
-    public void canReplaceThings() {
+    void canReplaceThings() {
         Unirest.jsonPatch(MockServer.PATCH)
                 .replace("/some/path", "a value")
                 .replace("/another/path", 42)
@@ -82,7 +80,7 @@ public class JsonPatchTest extends BddTest {
     }
 
     @Test
-    public void canTestThings() {
+    void canTestThings() {
         Unirest.jsonPatch(MockServer.PATCH)
                 .test("/some/path", "a value")
                 .test("/another/path", 42)
@@ -96,7 +94,7 @@ public class JsonPatchTest extends BddTest {
     }
 
     @Test
-    public void canUseJsonForValues() {
+    void canUseJsonForValues() {
         Unirest.jsonPatch(MockServer.PATCH)
                 .add("/some/path", new JSONObject().put("id", "foo"))
                 .asObject(RequestCapture.class)
@@ -105,7 +103,7 @@ public class JsonPatchTest extends BddTest {
     }
 
     @Test
-    public void lotsOfDifferentWaysToMakeObjects() {
+    void lotsOfDifferentWaysToMakeObjects() {
         JSONObject basicJson = new JSONObject().put("foo", "bar");
 
         Unirest.jsonPatch(MockServer.PATCH)
@@ -123,7 +121,7 @@ public class JsonPatchTest extends BddTest {
     }
 
     @Test
-    public void canMoveObjects() {
+    void canMoveObjects() {
         Unirest.jsonPatch(MockServer.PATCH)
                 .move("/old/location", "/new/location")
                 .asObject(RequestCapture.class)
@@ -132,7 +130,7 @@ public class JsonPatchTest extends BddTest {
     }
 
     @Test
-    public void canCopyObjects() {
+    void canCopyObjects() {
         Unirest.jsonPatch(MockServer.PATCH)
                 .copy("/old/location", "/new/location")
                 .asObject(RequestCapture.class)
@@ -141,7 +139,7 @@ public class JsonPatchTest extends BddTest {
     }
 
     @Test
-    public void thatsSomeValidJson() throws Exception {
+    void thatsSomeValidJson() throws Exception {
         String patch = Unirest.jsonPatch(MockServer.PATCH)
                 .add("/fruits/-", "Apple")
                 .remove("/bugs")

--- a/unirest/src/test/java/BehaviorTests/LifeCycleTest.java
+++ b/unirest/src/test/java/BehaviorTests/LifeCycleTest.java
@@ -48,13 +48,12 @@ import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class LifeCycleTest extends BddTest {
+class LifeCycleTest extends BddTest {
 
     @Mock
     private CloseableHttpClient httpc;
@@ -75,7 +74,7 @@ public class LifeCycleTest extends BddTest {
 
 
     @Test
-    public void ifClientsAreAlreadyRunningCanAddShutdownHooks() throws Exception  {
+    void ifClientsAreAlreadyRunningCanAddShutdownHooks() throws Exception  {
         assertShutdownHooks(0);
 
         Unirest.get(MockServer.GET).asEmpty();
@@ -87,7 +86,7 @@ public class LifeCycleTest extends BddTest {
     }
 
     @Test
-    public void canAddShutdownHooks() throws Exception {
+    void canAddShutdownHooks() throws Exception {
         assertShutdownHooks(0);
 
         Unirest.config().addShutdownHook(true).getClient();
@@ -97,7 +96,7 @@ public class LifeCycleTest extends BddTest {
     }
 
     @Test
-    public void settingClientAfterClientHasAlreadyBeenSet() {
+    void settingClientAfterClientHasAlreadyBeenSet() {
         HttpClientMock httpClientMock = new HttpClientMock();
         httpClientMock.onGet("http://localhost/getme").doReturn(202, "Howdy Ho!");
         assertEquals(200, Unirest.get(MockServer.GET).asString().getStatus());
@@ -108,7 +107,7 @@ public class LifeCycleTest extends BddTest {
     }
 
     @Test
-    public void willNotShutdownInactiveAsyncClient() throws IOException {
+    void willNotShutdownInactiveAsyncClient() throws IOException {
         CloseableHttpAsyncClient asyncClient = mock(CloseableHttpAsyncClient.class);
         when(asyncClient.isRunning()).thenReturn(false);
 
@@ -120,7 +119,7 @@ public class LifeCycleTest extends BddTest {
     }
 
     @Test
-    public void canDetectIfSystemIsRunning() {
+    void canDetectIfSystemIsRunning() {
         Unirest.get(MockServer.GET).asEmpty();
         assertTrue(Unirest.isRunning());
 
@@ -132,7 +131,7 @@ public class LifeCycleTest extends BddTest {
     }
 
     @Test
-    public void willReinitIfLibraryIsUsedAfterShutdown() {
+    void willReinitIfLibraryIsUsedAfterShutdown() {
         Unirest.shutDown();
         assertFalse(Unirest.isRunning());
 
@@ -141,14 +140,14 @@ public class LifeCycleTest extends BddTest {
     }
 
     @Test
-    public void canGetTheCommonInstanceOfUnirest(){
+    void canGetTheCommonInstanceOfUnirest(){
         assertSame(Unirest.primaryInstance(), Unirest.primaryInstance());
         assertNotSame(Unirest.primaryInstance(), Unirest.spawnInstance());
         assertNotSame(Unirest.spawnInstance(), Unirest.spawnInstance());
     }
 
     @Test
-    public void shouldReuseThreadPool() {
+    void shouldReuseThreadPool() {
         int startingCount = ManagementFactory.getThreadMXBean().getThreadCount();
         IntStream.range(0,100).forEach(i -> {
             Unirest.config().reset().getClient();
@@ -158,7 +157,7 @@ public class LifeCycleTest extends BddTest {
     }
 
     @Test
-    public void testUnirestInstanceIsShutdownWhenClosed() {
+    void testUnirestInstanceIsShutdownWhenClosed() {
         UnirestInstance reference;
         try (UnirestInstance instance = new UnirestInstance(new Config().setDefaultHeader("foo", "bar"))) {
             reference = instance;

--- a/unirest/src/test/java/BehaviorTests/MetricsTest.java
+++ b/unirest/src/test/java/BehaviorTests/MetricsTest.java
@@ -40,13 +40,14 @@ import static BehaviorTests.MockServer.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class MetricsTest extends BddTest {
+class MetricsTest extends BddTest {
     @Test
-    public void canSetAMetricObjectToInstramentUnirest() {
+    void canSetAMetricObjectToInstramentUnirest() {
         MyMetric metric = configureMetric();
 
         Unirest.get(GET).asEmpty();
@@ -61,7 +62,7 @@ public class MetricsTest extends BddTest {
     }
 
     @Test
-    public void canGetParamedUrlInSummary() {
+    void canGetParamedUrlInSummary() {
         MyMetric metric = configureMetric(HttpRequestSummary::getRawPath);
 
         Unirest.get(PASSED_PATH_PARAM)
@@ -73,7 +74,7 @@ public class MetricsTest extends BddTest {
     }
 
     @Test
-    public void canGetToMethod() {
+    void canGetToMethod() {
         MyMetric metric = configureMetric(s -> s.getHttpMethod().name());
 
         Unirest.get(GET).asEmpty();
@@ -86,7 +87,7 @@ public class MetricsTest extends BddTest {
     }
 
     @Test
-    public void amountOfTimeBetweenRequestAndResponseDoesNotIncludeDeserialization() {
+    void amountOfTimeBetweenRequestAndResponseDoesNotIncludeDeserialization() {
         MyMetric metric = configureMetric();
 
         Unirest.get(GET).asObject(r -> {
@@ -96,7 +97,7 @@ public class MetricsTest extends BddTest {
     }
 
     @Test
-    public void canGetInformationOnStatus() {
+    void canGetInformationOnStatus() {
         MyMetric metric = configureMetric(HttpRequestSummary::getUrl);
 
         Unirest.get(GET).asEmpty();
@@ -110,7 +111,7 @@ public class MetricsTest extends BddTest {
     }
 
     @Test
-    public void metricsOnAsyncRequests() throws Exception {
+    void metricsOnAsyncRequests() throws Exception {
         MyMetric metric = configureMetric();
 
         Unirest.get(GET).asEmptyAsync().get();
@@ -119,7 +120,7 @@ public class MetricsTest extends BddTest {
     }
 
     @Test
-    public void metricsOnAsyncMethodsWithCallbacks() {
+    void metricsOnAsyncMethodsWithCallbacks() {
         MyMetric metric = configureMetric();
 
         Unirest.get(GET).asEmptyAsync(r -> asyncSuccess());
@@ -129,7 +130,7 @@ public class MetricsTest extends BddTest {
     }
 
     @Test
-    public void errorHandling() throws Exception {
+    void errorHandling() throws Exception {
         HttpClient mock = mock(HttpClient.class);
         when(mock.execute(any(HttpRequestBase.class))).thenThrow(new RuntimeException("boo"));
         when(mock.execute(any(HttpHost.class), any(HttpRequestBase.class))).thenThrow(new RuntimeException("boo"));
@@ -146,7 +147,7 @@ public class MetricsTest extends BddTest {
     }
 
     @Test @Disabled
-    public void errorHandling_async() throws Exception {
+    void errorHandling_async() throws Exception {
         MyMetric metric = configureMetric();
 
         try {
@@ -162,7 +163,7 @@ public class MetricsTest extends BddTest {
     long exTime;
 
     @Test
-    public void metricAsALambda() {
+    void metricAsALambda() {
         exTime = 0;
         Unirest.config().instrumentWith((s) -> {
             long startNanos = System.nanoTime();
@@ -175,7 +176,7 @@ public class MetricsTest extends BddTest {
     }
 
     @Test
-    public void showWhatSparkDoes() {
+    void showWhatSparkDoes() {
         HashMap map = Unirest.get(SPARKLE)
                 .routeParam("spark", "joy")
                 .queryString("food", "hamberders")
@@ -186,7 +187,7 @@ public class MetricsTest extends BddTest {
         assertEquals("localhost:4567", map.get("host()"));
         assertEquals("/sparkle/joy/yippy", map.get("uri()")); // this is different from what the Spark doc says.
         assertEquals("http://localhost:4567/sparkle/joy/yippy", map.get("url()"));
-        assertEquals(null, map.get("contextPath()"));
+        assertNull(map.get("contextPath()"));
         assertEquals("/sparkle/joy/yippy", map.get("pathInfo()"));
         assertEquals("food=hamberders&colour=red", map.get("queryString()"));
     }

--- a/unirest/src/test/java/BehaviorTests/MockServer.java
+++ b/unirest/src/test/java/BehaviorTests/MockServer.java
@@ -41,8 +41,6 @@ import java.io.FileInputStream;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static spark.Spark.*;
 
@@ -134,11 +132,10 @@ public class MockServer {
 		sparks.put("pathInfo()", request.pathInfo());
 		sparks.put("port()", String.valueOf(request.port()));
 		sparks.put("protocol()", request.protocol());
-		sparks.put("requestMethod()", request.requestMethod());
 		sparks.put("scheme()", request.scheme());
 		sparks.put("servletPath()", request.servletPath());
 		sparks.put("requestMethod()", request.requestMethod());
-		sparks.put("splat()", Stream.of(request.splat()).collect(Collectors.joining(" | ")));
+		sparks.put("splat()", String.join(" | ", request.splat()));
 		sparks.put("uri()", request.uri());
 		sparks.put("url()", request.url());
 		sparks.put("userAgent()", request.userAgent());
@@ -258,10 +255,6 @@ public class MockServer {
 
 	public static void expectedPages(int expected) {
 		pages = expected;
-	}
-
-	public static void main(String[] args){
-
 	}
 
 	public static void expectCookie(String name, String value) {

--- a/unirest/src/test/java/BehaviorTests/MultiPartFormPostingTest.java
+++ b/unirest/src/test/java/BehaviorTests/MultiPartFormPostingTest.java
@@ -36,9 +36,10 @@ import static kong.unirest.TestUtil.getFileBytes;
 import static kong.unirest.TestUtil.rezFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MultiPartFormPostingTest extends BddTest {
+class MultiPartFormPostingTest extends BddTest {
+
     @Test
-    public void testMultipart() throws Exception {
+    void testMultipart() throws Exception {
         Unirest.post(MockServer.POST)
                 .field("name", "Mark")
                 .field("funky","bunch")
@@ -53,7 +54,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void fileSizeDoesntChange() throws Exception {
+    void fileSizeDoesntChange() throws Exception {
         File file = rezFile("/image.jpg");
         long size = file.length();
 
@@ -69,7 +70,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void testMultipartContentType() {
+    void testMultipartContentType() {
         Unirest.post(MockServer.POST)
                 .field("name", "Mark")
                 .field("file", rezFile("/image.jpg"), "image/jpeg")
@@ -82,7 +83,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void canSendRawInputStreamsWithoutAFileName()  throws Exception {
+    void canSendRawInputStreamsWithoutAFileName()  throws Exception {
         FileInputStream stream = new FileInputStream(rezFile("/test.txt"));
 
         Unirest.post(MockServer.POST)
@@ -93,7 +94,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void multipleFiles_sameField() {
+    void multipleFiles_sameField() {
         RequestCapture body = Unirest.post(MockServer.POST)
                 .field("file", rezFile("/image.jpg"))
                 .field("file", rezFile("/spidey.jpg"))
@@ -106,7 +107,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void testMultipartInputStreamContentType() throws Exception {
+    void testMultipartInputStreamContentType() throws Exception {
         FileInputStream stream = new FileInputStream(rezFile("/image.jpg"));
 
         Unirest.post(MockServer.POST)
@@ -123,7 +124,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void testMultipartInputStreamContentTypeAsync() throws Exception {
+    void testMultipartInputStreamContentTypeAsync() throws Exception {
         Unirest.post(MockServer.POST)
                 .field("name", "Mark")
                 .field("file", new FileInputStream(rezFile("/test.txt")), ContentType.APPLICATION_OCTET_STREAM, "test.txt")
@@ -138,7 +139,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void testMultipartByteContentType() throws Exception {
+    void testMultipartByteContentType() throws Exception {
         final byte[] bytes = getFileBytes("/image.jpg");
 
         Unirest.post(MockServer.POST)
@@ -152,7 +153,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void testMultipartByteContentTypeAsync() throws Exception {
+    void testMultipartByteContentTypeAsync() throws Exception {
         final byte[] bytes = getFileBytes("/test.txt");
 
         Unirest.post(MockServer.POST)
@@ -172,7 +173,7 @@ public class MultiPartFormPostingTest extends BddTest {
 
 
     @Test
-    public void testMultipartAsync() throws Exception {
+    void testMultipartAsync() throws Exception {
         Unirest.post(MockServer.POST)
                 .field("name", "Mark")
                 .field("file", rezFile("/test.txt"))
@@ -189,7 +190,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void utf8FileNames() {
+    void utf8FileNames() {
         InputStream fileData = new ByteArrayInputStream(new byte[] {'t', 'e', 's', 't'});
         final String filename = "fileäöü.pöf";
 
@@ -205,7 +206,7 @@ public class MultiPartFormPostingTest extends BddTest {
 
 
     @Test
-    public void canSetModeToStrictForLegacySupport() {
+    void canSetModeToStrictForLegacySupport() {
         InputStream fileData = new ByteArrayInputStream(new byte[] {'t', 'e', 's', 't'});
         final String filename = "fileäöü.pöf";
 
@@ -220,7 +221,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void canPostInputStreamWithContentType() throws Exception {
+    void canPostInputStreamWithContentType() throws Exception {
         File file = TestUtil.getImageFile();
         Unirest.post(MockServer.POST)
                 .field("testfile", new FileInputStream(file), ContentType.IMAGE_JPEG, "image.jpg")
@@ -233,7 +234,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void canPostInputStream() throws Exception {
+    void canPostInputStream() throws Exception {
         File file = TestUtil.getImageFile();
         Unirest.post(MockServer.POST)
                 .field("testfile", new FileInputStream(file), "image.jpg")
@@ -246,7 +247,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void postFieldsAsMap() throws URISyntaxException {
+    void postFieldsAsMap() throws URISyntaxException {
         File file = TestUtil.getImageFile();
 
         Unirest.post(MockServer.POST)
@@ -262,7 +263,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void postFileWithoutContentType() {
+    void postFileWithoutContentType() {
         File file = TestUtil.getImageFile();
         Unirest.post(MockServer.POST)
                 .field("testfile", file)
@@ -274,7 +275,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void postFileWithContentType() {
+    void postFileWithContentType() {
         File file = TestUtil.getImageFile();
         Unirest.post(MockServer.POST)
                 .field("testfile", file, ContentType.IMAGE_JPEG.getMimeType())
@@ -286,7 +287,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void multiPartInputStreamAsFile() throws FileNotFoundException {
+    void multiPartInputStreamAsFile() throws FileNotFoundException {
         Unirest.post(MockServer.POST)
                 .field("foo", "bar")
                 .field("filecontents", new FileInputStream(rezFile("/image.jpg")), "image.jpg")
@@ -300,7 +301,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void testPostMulipleFIles() {
+    void testPostMulipleFIles() {
         RequestCapture cap = Unirest.post(MockServer.POST)
                 .field("name", asList(rezFile("/test.txt"), rezFile("/test2.txt")))
                 .asObject(RequestCapture.class)
@@ -312,7 +313,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void testPostMultipleFiles()throws Exception {
+    void testPostMultipleFiles()throws Exception {
         Unirest.post(MockServer.POST)
                 .field("param3", "wot")
                 .field("file1", rezFile("/test.txt"))
@@ -326,7 +327,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void testPostBinaryUTF8() throws Exception {
+    void testPostBinaryUTF8() throws Exception {
         Unirest.post(MockServer.POST)
                 .header("Accept", ContentType.MULTIPART_FORM_DATA.getMimeType())
                 .field("param3", "こんにちは")
@@ -339,7 +340,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void testMultipeInputStreams() throws FileNotFoundException {
+    void testMultipeInputStreams() throws FileNotFoundException {
         Unirest.post(MockServer.POST)
                 .field("name", asList(new FileInputStream(rezFile("/test.txt")), new FileInputStream(rezFile("/test2.txt"))))
                 .asObject(RequestCapture.class)
@@ -350,7 +351,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void multiPartInputStream() throws FileNotFoundException {
+    void multiPartInputStream() throws FileNotFoundException {
         Unirest.post(MockServer.POST)
                 .field("foo", "bar")
                 .field("filecontents", new FileInputStream(rezFile("/test.txt")), ContentType.WILDCARD)
@@ -362,7 +363,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void passFileAsByteArray() {
+    void passFileAsByteArray() {
         Unirest.post(MockServer.POST)
                 .field("foo", "bar")
                 .field("filecontents", TestUtil.getFileBytes("/image.jpg"), ContentType.IMAGE_JPEG, "image.jpg")
@@ -376,7 +377,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void nullFileResultsInEmptyPost() {
+    void nullFileResultsInEmptyPost() {
         Unirest.post(MockServer.POST)
                 .field("testfile", (Object)null, ContentType.IMAGE_JPEG.getMimeType())
                 .asObject(RequestCapture.class)
@@ -386,7 +387,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void canForceIntoMultiPart() {
+    void canForceIntoMultiPart() {
         Unirest.post(MockServer.POST)
                 .multiPartContent()
                 .field("foo", "bar")
@@ -397,7 +398,7 @@ public class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
-    public void rawInspection() {
+    void rawInspection() {
         String body = Unirest.post(MockServer.ECHO_RAW)
                 .field("marky","mark")
                 .field("funky","bunch")

--- a/unirest/src/test/java/BehaviorTests/ObjectFunctionalTest.java
+++ b/unirest/src/test/java/BehaviorTests/ObjectFunctionalTest.java
@@ -35,12 +35,14 @@ import java.util.Map;
 
 import static com.google.common.collect.ImmutableMap.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ObjectFunctionalTest extends BddTest {
-    private Gson gson = new Gson();
+class ObjectFunctionalTest extends BddTest {
+
+    private final Gson gson = new Gson();
 
     @Test
-    public void canUseAFunctionToTransform() {
+    void canUseAFunctionToTransform() {
         MockServer.setJsonAsResponse(of("foo", "bar"));
 
         Map r = Unirest.get(MockServer.GET)
@@ -51,7 +53,7 @@ public class ObjectFunctionalTest extends BddTest {
     }
 
     @Test
-    public void canUseAFunctionToTransformAsync() throws Exception {
+    void canUseAFunctionToTransformAsync() throws Exception {
         MockServer.setJsonAsResponse(of("foo", "bar"));
 
         Map r = Unirest.get(MockServer.GET)
@@ -63,7 +65,7 @@ public class ObjectFunctionalTest extends BddTest {
     }
 
     @Test
-    public void willNotStopForParsingExceptions() {
+    void willNotStopForParsingExceptions() {
         MockServer.setStringResponse("call me ishmael");
 
         RuntimeException ohNoes = new RuntimeException("oh noes");
@@ -74,12 +76,13 @@ public class ObjectFunctionalTest extends BddTest {
                 });
 
         assertEquals(200, r.getStatus());
+        assertTrue(r.getParsingError().isPresent());
         assertEquals(ohNoes, r.getParsingError().get().getCause());
         assertEquals("call me ishmael", r.getParsingError().get().getOriginalBody());
     }
 
     @Test
-    public void willNotStopForParsingExceptions_async() throws Exception {
+    void willNotStopForParsingExceptions_async() throws Exception {
         MockServer.setStringResponse("call me ishmael");
 
         RuntimeException ohNoes = new RuntimeException("oh noes");
@@ -90,6 +93,7 @@ public class ObjectFunctionalTest extends BddTest {
                 }).get();
 
         assertEquals(200, r.getStatus());
+        assertTrue(r.getParsingError().isPresent());
         assertEquals(ohNoes, r.getParsingError().get().getCause());
         assertEquals("call me ishmael", r.getParsingError().get().getOriginalBody());
     }

--- a/unirest/src/test/java/BehaviorTests/PagingTest.java
+++ b/unirest/src/test/java/BehaviorTests/PagingTest.java
@@ -31,10 +31,10 @@ import kong.unirest.Unirest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class PagingTest extends BddTest {
+class PagingTest extends BddTest {
 
     @Test
-    public void canFollowPaging() {
+    void canFollowPaging() {
         MockServer.expectedPages(10);
 
         PagedList<RequestCapture> result =  Unirest.get(MockServer.PAGED)
@@ -47,7 +47,7 @@ public class PagingTest extends BddTest {
     }
 
     @Test
-    public void canCapturePagesAsStrings() {
+    void canCapturePagesAsStrings() {
         MockServer.expectedPages(10);
 
         PagedList<String> result =  Unirest.get(MockServer.PAGED)
@@ -60,7 +60,7 @@ public class PagingTest extends BddTest {
     }
 
     @Test
-    public void willReturnOnePageIfthereWasNoPaging() {
+    void willReturnOnePageIfthereWasNoPaging() {
 
         PagedList<RequestCapture> result =  Unirest.get(MockServer.PAGED)
                 .asPaged(

--- a/unirest/src/test/java/BehaviorTests/PathParamTest.java
+++ b/unirest/src/test/java/BehaviorTests/PathParamTest.java
@@ -31,10 +31,10 @@ import kong.unirest.UnirestException;
 import org.junit.jupiter.api.Test;
 import kong.unirest.TestUtil;
 
-public class PathParamTest extends BddTest {
+class PathParamTest extends BddTest {
 
     @Test
-    public void canAddRouteParamsAsMap() {
+    void canAddRouteParamsAsMap() {
         String param = "Hamberders";
 
         Unirest.get(MockServer.PASSED_PATH_PARAM_MULTI)
@@ -47,7 +47,7 @@ public class PathParamTest extends BddTest {
     }
 
     @Test
-    public void properlyDealsWithPlusInPAth() {
+    void properlyDealsWithPlusInPAth() {
         String param = "jack+4@email.com";
 
         Unirest.get(MockServer.PASSED_PATH_PARAM)
@@ -59,7 +59,7 @@ public class PathParamTest extends BddTest {
     }
 
     @Test
-    public void testPathParameters() {
+    void testPathParameters() {
         Unirest.get(MockServer.HOST + "/{method}")
                 .routeParam("method", "get")
                 .queryString("name", "Mark")
@@ -69,7 +69,7 @@ public class PathParamTest extends BddTest {
     }
 
     @Test
-    public void testQueryAndBodyParameters() {
+    void testQueryAndBodyParameters() {
         Unirest.post(MockServer.HOST + "/{method}")
                 .routeParam("method", "post")
                 .queryString("name", "Mark")
@@ -81,7 +81,7 @@ public class PathParamTest extends BddTest {
     }
 
     @Test
-    public void testPathParameters2() {
+    void testPathParameters2() {
         Unirest.patch(MockServer.HOST + "/{method}")
                 .routeParam("method", "patch")
                 .field("name", "Mark")
@@ -91,7 +91,7 @@ public class PathParamTest extends BddTest {
     }
 
     @Test
-    public void testMissingPathParameter() {
+    void testMissingPathParameter() {
         TestUtil.assertException(() ->
                         Unirest.get(MockServer.HOST + "/{method}")
                         .routeParam("method222", "get")
@@ -102,7 +102,7 @@ public class PathParamTest extends BddTest {
     }
 
     @Test
-    public void testMissingPathParameterValue() {
+    void testMissingPathParameterValue() {
         TestUtil.assertException(() ->
                         Unirest.get(MockServer.HOST + "/{method}")
                                 .queryString("name", "Mark")
@@ -112,7 +112,7 @@ public class PathParamTest extends BddTest {
     }
 
     @Test
-    public void illigalPathParams() {
+    void illigalPathParams() {
         String value = "/?ЊЯЯ";
 
         Unirest.get(MockServer.PASSED_PATH_PARAM)
@@ -124,7 +124,7 @@ public class PathParamTest extends BddTest {
     }
 
     @Test
-    public void spacesAndPluses() {
+    void spacesAndPluses() {
         String value = "Hunky Dory+Cheese Wiz";
 
         Unirest.get(MockServer.PASSED_PATH_PARAM)
@@ -136,7 +136,7 @@ public class PathParamTest extends BddTest {
     }
 
     @Test
-    public void nulls() {
+    void nulls() {
         Unirest.get(MockServer.PASSED_PATH_PARAM)
                 .routeParam("params", null)
                 .asObject(RequestCapture.class)

--- a/unirest/src/test/java/BehaviorTests/PostRequestHandlersTest.java
+++ b/unirest/src/test/java/BehaviorTests/PostRequestHandlersTest.java
@@ -25,7 +25,6 @@
 
 package BehaviorTests;
 
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import kong.unirest.HttpResponse;
@@ -35,7 +34,7 @@ import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PostRequestHandlersTest extends BddTest {
+class PostRequestHandlersTest extends BddTest {
 
     private HttpResponse<RequestCapture> captured;
 
@@ -47,7 +46,7 @@ public class PostRequestHandlersTest extends BddTest {
     }
 
     @Test
-    public void onSuccessDoSomething() {
+    void onSuccessDoSomething() {
         Unirest.get(MockServer.GET)
                 .queryString("foo", "bar")
                 .asObject(RequestCapture.class)
@@ -59,7 +58,7 @@ public class PostRequestHandlersTest extends BddTest {
     }
 
     @Test
-    public void onFailDoSomething() {
+    void onFailDoSomething() {
         Unirest.get(MockServer.INVALID_REQUEST)
                 .queryString("foo", "bar")
                 .asObject(RequestCapture.class)
@@ -71,7 +70,7 @@ public class PostRequestHandlersTest extends BddTest {
     }
 
     @Test
-    public void itsAFailIfTheMapperFails() {
+    void itsAFailIfTheMapperFails() {
         MockServer.setStringResponse("not what you expect");
 
         Unirest.get(MockServer.GET)
@@ -87,7 +86,7 @@ public class PostRequestHandlersTest extends BddTest {
     }
 
     @Test
-    public void canConfigureAGlobalErrorHandler(){
+    void canConfigureAGlobalErrorHandler(){
         Error error = new Error();
         Unirest.config().errorHandler(error);
 
@@ -97,7 +96,7 @@ public class PostRequestHandlersTest extends BddTest {
     }
 
     @Test
-    public void canConfigureAGlobalErrorHandlerAsync()  throws Exception {
+    void canConfigureAGlobalErrorHandlerAsync()  throws Exception {
         Error error = new Error();
         Unirest.config().errorHandler(error);
 
@@ -106,7 +105,7 @@ public class PostRequestHandlersTest extends BddTest {
         assertEquals(400, error.httpResponse.getStatus());
     }
 
-    private class Error implements Consumer<HttpResponse<?>> {
+    private static class Error implements Consumer<HttpResponse<?>> {
 
         public HttpResponse<?> httpResponse;
 
@@ -120,7 +119,7 @@ public class PostRequestHandlersTest extends BddTest {
 
 
     @Test
-    public void onSuccessBeSuccessful() {
+    void onSuccessBeSuccessful() {
         HttpResponse<RequestCapture> response = Unirest.get(MockServer.GET)
             .queryString("foo", "bar")
             .asObject(RequestCapture.class);
@@ -129,7 +128,7 @@ public class PostRequestHandlersTest extends BddTest {
     }
 
     @Test
-    public void onFailBeUnsuccessful() {
+    void onFailBeUnsuccessful() {
         HttpResponse<RequestCapture> response = Unirest.get(MockServer.INVALID_REQUEST)
             .queryString("foo", "bar")
             .asObject(RequestCapture.class);
@@ -138,7 +137,7 @@ public class PostRequestHandlersTest extends BddTest {
     }
 
     @Test
-    public void beUnsuccessfulIfTheMapperFails() {
+    void beUnsuccessfulIfTheMapperFails() {
         MockServer.setStringResponse("not what you expect");
 
         HttpResponse<RequestCapture> response = Unirest.get(MockServer.GET)

--- a/unirest/src/test/java/BehaviorTests/ProxyTest.java
+++ b/unirest/src/test/java/BehaviorTests/ProxyTest.java
@@ -35,7 +35,7 @@ import kong.unirest.Unirest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Disabled // The Janky Proxy is pretty janky and isn't entirely stable in CI
-public class ProxyTest extends BddTest {
+class ProxyTest extends BddTest {
 
     @AfterEach
     @Override
@@ -46,7 +46,7 @@ public class ProxyTest extends BddTest {
     }
 
     @Test
-    public void canUseNonAuthProxy() {
+    void canUseNonAuthProxy() {
         JankyProxy.runServer("localhost", 4567, 7777);
 
         Unirest.config().proxy(new Proxy("localhost", 7777));
@@ -60,7 +60,7 @@ public class ProxyTest extends BddTest {
     }
 
     @Test
-    public void canUseNonAuthProxyWithEasyMethod() {
+    void canUseNonAuthProxyWithEasyMethod() {
         JankyProxy.runServer("localhost", 4567, 7777);
 
         Unirest.config().proxy("localhost", 7777);
@@ -74,7 +74,7 @@ public class ProxyTest extends BddTest {
     }
 
     @Test
-    public void canPassProxyOnRequest() {
+    void canPassProxyOnRequest() {
         JankyProxy.runServer("localhost", 4567, 7777);
 
         Unirest.get(MockServer.GET)
@@ -87,7 +87,7 @@ public class ProxyTest extends BddTest {
     }
 
     @Test
-    public void canSetAuthenticatedProxy(){
+    void canSetAuthenticatedProxy(){
         JankyProxy.runServer("localhost", 4567, 7777);
 
         Unirest.config().proxy("localhost", 7777, "username", "password1!");
@@ -102,7 +102,7 @@ public class ProxyTest extends BddTest {
 
     @Test
     @Disabled // there is some weird conflict between jetty and unirest here
-    public void canFlagTheClientsToUseSystemProperties(){
+    void canFlagTheClientsToUseSystemProperties(){
         JankyProxy.runServer("localhost", 4567, 7777);
 
         System.setProperty("http.proxyHost", "localhost");
@@ -119,7 +119,7 @@ public class ProxyTest extends BddTest {
     }
 
     @Test @Disabled // https://free-proxy-list.net/
-    public void callSomethingRealThroughARealProxy() {
+    void callSomethingRealThroughARealProxy() {
         Unirest.config().proxy("18.222.230.116",8080);
         //Unirest.config().proxy("34.73.62.46",3128, "myuser","pass1!");
         HttpResponse<String> r = Unirest.get("https://twitter.com/ryber").asString();

--- a/unirest/src/test/java/BehaviorTests/QueryStringTest.java
+++ b/unirest/src/test/java/BehaviorTests/QueryStringTest.java
@@ -32,9 +32,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-public class QueryStringTest extends BddTest {
+class QueryStringTest extends BddTest {
+
     @Test
-    public void testGetQueryStrings() {
+    void testGetQueryStrings() {
        Unirest.get(MockServer.GET)
                 .queryString("name", "mark")
                 .queryString("nick", "thefosk")
@@ -45,7 +46,7 @@ public class QueryStringTest extends BddTest {
     }
 
     @Test
-    public void canPassQueryParamsDirectlyOnUriOrWithMethod() {
+    void canPassQueryParamsDirectlyOnUriOrWithMethod() {
         Unirest.get(MockServer.GET + "?name=mark")
                 .asObject(RequestCapture.class)
                 .getBody()
@@ -59,7 +60,7 @@ public class QueryStringTest extends BddTest {
     }
 
     @Test
-    public void canPassInACharSequence() {
+    void canPassInACharSequence() {
         Unirest.get(MockServer.GET)
                 .queryString("foo", new StringBuilder("bar"))
                 .asObject(RequestCapture.class)
@@ -68,7 +69,7 @@ public class QueryStringTest extends BddTest {
     }
 
     @Test
-    public void multipleParams() {
+    void multipleParams() {
         Unirest.get(MockServer.GET + "?name=ringo")
                 .queryString("name", "paul")
                 .queryString("name", "john")
@@ -80,7 +81,7 @@ public class QueryStringTest extends BddTest {
     }
 
     @Test
-    public void testGetUTF8() {
+    void testGetUTF8() {
         Unirest.get(MockServer.GET)
                 .queryString("param3", "こんにちは")
                 .asObject(RequestCapture.class)
@@ -89,7 +90,7 @@ public class QueryStringTest extends BddTest {
     }
 
     @Test
-    public void testGetMultiple() {
+    void testGetMultiple() {
         for (int i = 1; i <= 20; i++) {
             HttpResponse<JsonNode> response = Unirest.get(MockServer.GET + "?try=" + i).asJson();
             parse(response).assertParam("try", String.valueOf(i));
@@ -97,7 +98,7 @@ public class QueryStringTest extends BddTest {
     }
 
     @Test
-    public void testQueryStringEncoding() {
+    void testQueryStringEncoding() {
         String testKey = "email2=someKey&email";
         String testValue = "hello@hello.com";
 
@@ -109,7 +110,7 @@ public class QueryStringTest extends BddTest {
     }
 
     @Test
-    public void testGetQuerystringArray() {
+    void testGetQuerystringArray() {
         Unirest.get(MockServer.GET)
                 .queryString("name", "Mark")
                 .queryString("name", "Tom")
@@ -120,7 +121,7 @@ public class QueryStringTest extends BddTest {
     }
 
     @Test
-    public void testGetArray() {
+    void testGetArray() {
         Unirest.get(MockServer.GET)
                 .queryString("name", Arrays.asList("Mark", "Tom"))
                 .asObject(RequestCapture.class)

--- a/unirest/src/test/java/BehaviorTests/RawUrlTest.java
+++ b/unirest/src/test/java/BehaviorTests/RawUrlTest.java
@@ -28,9 +28,10 @@ package BehaviorTests;
 import kong.unirest.Unirest;
 import org.junit.jupiter.api.Test;
 
-public class RawUrlTest extends BddTest {
+class RawUrlTest extends BddTest {
+
     @Test
-    public void canCallRawPathWithSpace() {
+    void canCallRawPathWithSpace() {
         Unirest.get(MockServer.GET + "/foo/passed/Moody Blues")
                 .asObject(RequestCapture.class)
                 .getBody()
@@ -38,7 +39,7 @@ public class RawUrlTest extends BddTest {
     }
 
     @Test
-    public void canCallRawPathWithTab() {
+    void canCallRawPathWithTab() {
         Unirest.get(MockServer.GET + "/foo/passed/Moody\tBlues")
                 .asObject(RequestCapture.class)
                 .getBody()
@@ -46,7 +47,7 @@ public class RawUrlTest extends BddTest {
     }
 
     @Test
-    public void doesNotImpactPathParams() {
+    void doesNotImpactPathParams() {
         Unirest.get(MockServer.GET + "/{first param}/passed/{file name}")
                 .routeParam("first param", "foo")
                 .routeParam("file name", "Moody Blues")

--- a/unirest/src/test/java/BehaviorTests/RedirectHandlingTest.java
+++ b/unirest/src/test/java/BehaviorTests/RedirectHandlingTest.java
@@ -33,10 +33,10 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class RedirectHandlingTest extends BddTest {
+class RedirectHandlingTest extends BddTest {
 
     @Test
-    public void willFollowRedirectsByDefault() {
+    void willFollowRedirectsByDefault() {
         Unirest.get(MockServer.REDIRECT)
                 .asObject(RequestCapture.class)
                 .getBody()
@@ -44,7 +44,7 @@ public class RedirectHandlingTest extends BddTest {
     }
 
     @Test
-    public void canDisableRedirects(){
+    void canDisableRedirects(){
         Unirest.config().followRedirects(false);
         HttpResponse response = Unirest.get(MockServer.REDIRECT).asEmpty();
 
@@ -52,7 +52,7 @@ public class RedirectHandlingTest extends BddTest {
     }
 
     @Test
-    public void willFollowRedirectsByDefaultAsync() throws ExecutionException, InterruptedException {
+    void willFollowRedirectsByDefaultAsync() throws ExecutionException, InterruptedException {
         Unirest.get(MockServer.REDIRECT)
                 .asObjectAsync(RequestCapture.class)
                 .get()
@@ -61,7 +61,7 @@ public class RedirectHandlingTest extends BddTest {
     }
 
     @Test
-    public void canDisableRedirectsAsync() throws Exception {
+    void canDisableRedirectsAsync() throws Exception {
         Unirest.config().followRedirects(false);
         HttpResponse response = Unirest.get(MockServer.REDIRECT).asEmptyAsync().get();
 

--- a/unirest/src/test/java/BehaviorTests/RequestCapture.java
+++ b/unirest/src/test/java/BehaviorTests/RequestCapture.java
@@ -41,6 +41,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.Part;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -99,7 +100,7 @@ public class RequestCapture {
     }
 
     private void parseBodyToFormParams() {
-        URLEncodedUtils.parse(this.body, Charset.forName("UTF-8"))
+        URLEncodedUtils.parse(this.body, StandardCharsets.UTF_8)
                 .forEach(p -> {
                     params.put(p.getName(), p.getValue());
                 });
@@ -154,11 +155,6 @@ public class RequestCapture {
 
     private void writeQuery(Request req) {
         req.queryParams().forEach(q -> params.putAll(q, Sets.newHashSet(req.queryMap(q).values())));
-    }
-
-    public RequestCapture asserBody(String s) {
-        assertEquals(s, body);
-        return this;
     }
 
     public RequestCapture assertNoHeader(String s) {
@@ -224,7 +220,7 @@ public class RequestCapture {
         return this;
     }
 
-    public RequestCapture asserMethod(HttpMethod get) {
+    public RequestCapture assertMethod(HttpMethod get) {
         assertEquals(get, method);
         return this;
     }
@@ -272,8 +268,9 @@ public class RequestCapture {
         return this;
     }
 
-    public void assertBody(String o) {
+    public RequestCapture assertBody(String o) {
         assertEquals(o, body);
+        return this;
     }
 
     public void setStatus(int i) {

--- a/unirest/src/test/java/BehaviorTests/ResponseHeaderTest.java
+++ b/unirest/src/test/java/BehaviorTests/ResponseHeaderTest.java
@@ -32,11 +32,11 @@ import kong.unirest.Unirest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ResponseHeaderTest extends BddTest {
+class ResponseHeaderTest extends BddTest {
 
 
     @Test
-    public void responseHeadersAreInTheSameOrderAsTheResponse() {
+    void responseHeadersAreInTheSameOrderAsTheResponse() {
         MockServer.addResponseHeader("zed", "oranges");
         MockServer.addResponseHeader("alpha", "apples");
         MockServer.addResponseHeader("Content", "application/xml");

--- a/unirest/src/test/java/BehaviorTests/TestMonitor.java
+++ b/unirest/src/test/java/BehaviorTests/TestMonitor.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static java.util.Arrays.asList;
 import static kong.unirest.TestUtil.defaultIfNull;
 import static kong.unirest.TestUtil.rezFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/unirest/src/test/java/BehaviorTests/TimeoutTest.java
+++ b/unirest/src/test/java/BehaviorTests/TimeoutTest.java
@@ -46,10 +46,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Disabled
-public class TimeoutTest extends BddTest {
+class TimeoutTest extends BddTest {
 
     @Test
-    public void testSetTimeouts() {
+    void testSetTimeouts() {
         String address = MockServer.GET;
         long start = System.currentTimeMillis();
         try {
@@ -74,7 +74,7 @@ public class TimeoutTest extends BddTest {
 
     @Test
     @Disabled // this is flakey
-    public void parallelTest() throws InterruptedException {
+    void parallelTest() throws InterruptedException {
         Unirest.config().connectTimeout(10).socketTimeout(5);
 
         long start = System.currentTimeMillis();

--- a/unirest/src/test/java/BehaviorTests/UniBodyPostingTest.java
+++ b/unirest/src/test/java/BehaviorTests/UniBodyPostingTest.java
@@ -35,9 +35,10 @@ import java.nio.charset.StandardCharsets;
 import static kong.unirest.TestUtil.assertException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class UniBodyPostingTest extends BddTest {
+class UniBodyPostingTest extends BddTest {
+
     @Test
-    public void testDefaults_String(){
+    void testDefaults_String(){
         Unirest.post(MockServer.POST)
                 .body("foo")
                 .asObject(RequestCapture.class)
@@ -46,31 +47,31 @@ public class UniBodyPostingTest extends BddTest {
     }
 
     @Test
-    public void canSetCharsetOfBody(){
+    void canSetCharsetOfBody(){
         Unirest.post(MockServer.POST)
                 .charset(StandardCharsets.US_ASCII)
                 .body("foo")
                 .asObject(RequestCapture.class)
                 .getBody()
                 .assertContentType("text/plain; charset=US-ASCII")
-                .asserBody("foo")
+                .assertBody("foo")
                 .assertCharset(StandardCharsets.US_ASCII);
     }
 
     @Test
-    public void canSetCharsetOfBodyAfterMovingToBody(){
+    void canSetCharsetOfBodyAfterMovingToBody(){
         Unirest.post(MockServer.POST)
                 .body("foo")
                 .charset(StandardCharsets.US_ASCII)
                 .asObject(RequestCapture.class)
                 .getBody()
                 .assertContentType("text/plain; charset=US-ASCII")
-                .asserBody("foo")
+                .assertBody("foo")
                 .assertCharset(StandardCharsets.US_ASCII);
     }
 
     @Test
-    public void testPostRawBody() {
+    void testPostRawBody() {
         String sourceString = "'\"@こんにちは-test-123-" + Math.random();
         byte[] sentBytes = sourceString.getBytes();
 
@@ -78,17 +79,17 @@ public class UniBodyPostingTest extends BddTest {
                 .body(sentBytes)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserBody(sourceString);
+                .assertBody(sourceString);
     }
 
     @Test
-    public void testAsyncCustomContentType() {
+    void testAsyncCustomContentType() {
         Unirest.post(MockServer.POST)
                 .header("accept", "application/json")
                 .header("Content-Type", "application/json")
                 .body("{\"hello\":\"world\"}")
                 .asJsonAsync(new MockCallback<>(this, r -> parse(r)
-                        .asserBody("{\"hello\":\"world\"}")
+                        .assertBody("{\"hello\":\"world\"}")
                         .assertHeader("Content-Type", "application/json"))
                 );
 
@@ -97,7 +98,7 @@ public class UniBodyPostingTest extends BddTest {
 
 
     @Test
-    public void postAPojoObjectUsingTheMapper() {
+    void postAPojoObjectUsingTheMapper() {
         GetResponse postResponseMock = new GetResponse();
         postResponseMock.setUrl(MockServer.POST);
 
@@ -107,21 +108,21 @@ public class UniBodyPostingTest extends BddTest {
                 .body(postResponseMock)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserBody("{\"url\":\"http://localhost:4567/post\"}");
+                .assertBody("{\"url\":\"http://localhost:4567/post\"}");
     }
 
     @Test
-    public void testDeleteBody() {
+    void testDeleteBody() {
         String body = "{\"jsonString\":{\"members\":\"members1\"}}";
         Unirest.delete(MockServer.DELETE)
                 .body(body)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserBody(body);
+                .assertBody(body);
     }
 
     @Test
-    public void postBodyAsJson() {
+    void postBodyAsJson() {
         JSONObject body = new JSONObject();
         body.put("krusty","krab");
 
@@ -129,11 +130,11 @@ public class UniBodyPostingTest extends BddTest {
                 .body(body)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserBody("{\"krusty\":\"krab\"}");
+                .assertBody("{\"krusty\":\"krab\"}");
     }
 
     @Test
-    public void postBodyAsJsonArray() {
+    void postBodyAsJsonArray() {
         JSONArray body = new JSONArray();
         body.put(0, "krusty");
         body.put(1, "krab");
@@ -142,22 +143,22 @@ public class UniBodyPostingTest extends BddTest {
                 .body(body)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserBody("[\"krusty\",\"krab\"]");
+                .assertBody("[\"krusty\",\"krab\"]");
     }
 
     @Test
-    public void postBodyAsJsonNode() {
+    void postBodyAsJsonNode() {
         JsonNode body = new JsonNode("{\"krusty\":\"krab\"}");
 
         Unirest.post(MockServer.POST)
                 .body(body)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserBody("{\"krusty\":\"krab\"}");
+                .assertBody("{\"krusty\":\"krab\"}");
     }
 
     @Test
-    public void cantPostObjectWithoutObjectMapper(){
+    void cantPostObjectWithoutObjectMapper(){
         Unirest.config().setObjectMapper(null);
 
         assertException(() -> Unirest.post(MockServer.POST).body(new Foo("die")),

--- a/unirest/src/test/java/BehaviorTests/UploadProgressTest.java
+++ b/unirest/src/test/java/BehaviorTests/UploadProgressTest.java
@@ -46,7 +46,7 @@ public class UploadProgressTest extends BddTest {
     }
 
     @Test
-    public void canAddUploadProgress() {
+    void canAddUploadProgress() {
         Unirest.post(MockServer.POST)
                 .field("spidey", monitor.spidey)
                 .uploadMonitor(monitor)
@@ -56,7 +56,7 @@ public class UploadProgressTest extends BddTest {
     }
 
     @Test
-    public void canAddUploadProgressAsync() throws Exception {
+    void canAddUploadProgressAsync() throws Exception {
         Unirest.post(MockServer.POST)
                 .field("spidey", monitor.spidey)
                 .uploadMonitor(monitor)
@@ -66,7 +66,7 @@ public class UploadProgressTest extends BddTest {
     }
 
     @Test
-    public void canKeepTrackOfMultipleFiles() {
+    void canKeepTrackOfMultipleFiles() {
         Unirest.post(MockServer.POST)
                 .field("spidey", monitor.spidey)
                 .field("other", rezFile("/test.txt"))
@@ -78,7 +78,7 @@ public class UploadProgressTest extends BddTest {
     }
 
     @Test
-    public void canMonitorIfPassedAsInputStream() throws Exception {
+    void canMonitorIfPassedAsInputStream() throws Exception {
         Unirest.post(MockServer.POST)
                 .field("spidey", new FileInputStream(monitor.spidey))
                 .uploadMonitor(monitor)

--- a/unirest/src/test/java/BehaviorTests/VerbTest.java
+++ b/unirest/src/test/java/BehaviorTests/VerbTest.java
@@ -32,41 +32,42 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class VerbTest extends BddTest {
+class VerbTest extends BddTest {
+
     @Test
-    public void get() {
+    void get() {
         Unirest.get(MockServer.GET)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserMethod(HttpMethod.GET);
+                .assertMethod(HttpMethod.GET);
     }
 
     @Test
-    public void post() {
+    void post() {
         Unirest.post(MockServer.POST)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserMethod(HttpMethod.POST);
+                .assertMethod(HttpMethod.POST);
     }
 
     @Test
-    public void put() {
+    void put() {
         Unirest.put(MockServer.POST)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserMethod(HttpMethod.PUT);
+                .assertMethod(HttpMethod.PUT);
     }
 
     @Test
-    public void patch() {
+    void patch() {
         Unirest.patch(MockServer.PATCH)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserMethod(HttpMethod.PATCH);
+                .assertMethod(HttpMethod.PATCH);
     }
 
     @Test
-    public void head() {
+    void head() {
         HttpResponse response = Unirest.head(MockServer.GET).asEmpty();
 
         assertEquals(200, response.getStatus());
@@ -74,19 +75,19 @@ public class VerbTest extends BddTest {
     }
 
     @Test
-    public void option() {
+    void option() {
         Unirest.options(MockServer.GET)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserMethod(HttpMethod.OPTIONS);
+                .assertMethod(HttpMethod.OPTIONS);
     }
 
     @Test
-    public void weirdVerbs() {
+    void weirdVerbs() {
         Unirest.request("CHEESE", MockServer.CHEESE)
                 .asObject(RequestCapture.class)
                 .getBody()
-                .asserMethod(HttpMethod.valueOf("CHEESE"))
+                .assertMethod(HttpMethod.valueOf("CHEESE"))
                 .assertBody("");
     }
 }

--- a/unirest/src/test/java/kong/unirest/BaseRequestTest.java
+++ b/unirest/src/test/java/kong/unirest/BaseRequestTest.java
@@ -37,22 +37,22 @@ import static com.google.common.collect.ImmutableMap.of;
 import static kong.unirest.HttpMethod.GET;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class BaseRequestTest {
+class BaseRequestTest {
 
     private Config testConfig;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         testConfig = new Config();
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         Util.resetClock();
     }
 
     @Test
-    public void socketTimeoutCanOverrrideConfig() {
+    void socketTimeoutCanOverrrideConfig() {
         testConfig.socketTimeout(42);
 
         HttpRequest request = new TestRequest(testConfig);
@@ -63,7 +63,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void connectTimeoutCanOverrrideConfig() {
+    void connectTimeoutCanOverrrideConfig() {
         testConfig.connectTimeout(42);
 
         HttpRequest request = new TestRequest(testConfig);
@@ -74,7 +74,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void copiesSettingsFromOtherRequest() {
+    void copiesSettingsFromOtherRequest() {
         testConfig.connectTimeout(42);
         testConfig.socketTimeout(42);
 
@@ -87,7 +87,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void canPassABasicProxyPerRequest() {
+    void canPassABasicProxyPerRequest() {
         Proxy cp = new Proxy("foo", 8080, "username", "password");
         testConfig.proxy(cp);
 
@@ -100,7 +100,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void requestEquals_PathAndVerb() {
+    void requestEquals_PathAndVerb() {
         assertEquals(
                 new TestRequest(GET, "/path"),
                 new TestRequest(GET, "/path")
@@ -108,7 +108,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void requestEquals_PathAndVerb_differentVerb() {
+    void requestEquals_PathAndVerb_differentVerb() {
         assertNotEquals(
                 new TestRequest(GET, "/path"),
                 new TestRequest(HttpMethod.HEAD, "/path")
@@ -116,7 +116,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void requestEquals_PathAndVerb_differentPath() {
+    void requestEquals_PathAndVerb_differentPath() {
         assertNotEquals(
                 new TestRequest(GET, "/path"),
                 new TestRequest(GET, "/derp")
@@ -124,7 +124,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void reqeustEquals_Headers() {
+    void reqeustEquals_Headers() {
         assertEquals(
                 new TestRequest(of("Accept", "json")),
                 new TestRequest(of("Accept", "json"))
@@ -132,7 +132,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void reqeustEquals_Headers_differentValues() {
+    void reqeustEquals_Headers_differentValues() {
         assertNotEquals(
                 new TestRequest(of("Accept", "json")),
                 new TestRequest(of("Accept", "xml"))
@@ -140,7 +140,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void reqeustEquals_Headers_additionalValues() {
+    void reqeustEquals_Headers_additionalValues() {
         assertNotEquals(
                 new TestRequest(of("Accept", "json")),
                 new TestRequest(of("Accept", "json", "x-header", "cheese"))
@@ -148,14 +148,14 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void canGetTimeOfRequest() {
+    void canGetTimeOfRequest() {
         TestRequest request = new TestRequest();
 
         assertTrue(ChronoUnit.MILLIS.between(request.getCreationTime(), Instant.now()) < 10);
     }
 
     @Test
-    public void canFreezeTimeForTests() {
+    void canFreezeTimeForTests() {
         Instant i = Instant.now();
         Util.freezeClock(i);
         TestRequest r1 = new TestRequest();

--- a/unirest/src/test/java/kong/unirest/BodyTest.java
+++ b/unirest/src/test/java/kong/unirest/BodyTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class BodyTest {
+
     @Test
     void canGetPartsByName() {
         Body b = new TestBody(

--- a/unirest/src/test/java/kong/unirest/CacheManagerTest.java
+++ b/unirest/src/test/java/kong/unirest/CacheManagerTest.java
@@ -87,7 +87,7 @@ class CacheManagerTest {
         assertEquals(2, client.invokes);
     }
 
-    private class MockClient implements Client, AsyncClient {
+    private static class MockClient implements Client, AsyncClient {
         public int invokes = 0;
         @Override
         public <T> CompletableFuture<HttpResponse<T>> request(HttpRequest request, Function<RawResponse, HttpResponse<T>> transformer, CompletableFuture<HttpResponse<T>> callback) {

--- a/unirest/src/test/java/kong/unirest/ClientFactoryTest.java
+++ b/unirest/src/test/java/kong/unirest/ClientFactoryTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 
-public class ClientFactoryTest {
+class ClientFactoryTest {
 
     @BeforeEach
     @AfterEach
@@ -49,14 +49,14 @@ public class ClientFactoryTest {
     }
 
     @Test
-    public void shouldReuseThreadPool() {
+    void shouldReuseThreadPool() {
         int startingCount = ManagementFactory.getThreadMXBean().getThreadCount();
         //IntStream.range(0,100).forEach(i -> ClientFactory.refresh());
         assertThat(ManagementFactory.getThreadMXBean().getThreadCount(), is(lessThan(startingCount + 10)));
     }
 
     @Test
-    public void canSaveSomeOptions(){
+    void canSaveSomeOptions(){
         HttpRequestInterceptor i = mock(HttpRequestInterceptor.class);
         CloseableHttpAsyncClient c = mock(CloseableHttpAsyncClient.class);
 

--- a/unirest/src/test/java/kong/unirest/CompoundInterceptorTest.java
+++ b/unirest/src/test/java/kong/unirest/CompoundInterceptorTest.java
@@ -98,7 +98,7 @@ class CompoundInterceptorTest {
     @Test
     void willThrowIfNothingElse() {
         CompoundInterceptor compound = new CompoundInterceptor(
-                Arrays.asList()
+                Collections.emptyList()
         );
 
         RuntimeException e = new RuntimeException();

--- a/unirest/src/test/java/kong/unirest/ConfigTest.java
+++ b/unirest/src/test/java/kong/unirest/ConfigTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
-public class ConfigTest {
+class ConfigTest {
 
     @Mock
     private CloseableHttpClient httpc;
@@ -68,27 +68,27 @@ public class ConfigTest {
     private Config config;
 
     @Test
-    public void shouldKeepConnectionTimeOutDefault(){
+    void shouldKeepConnectionTimeOutDefault(){
         assertEquals(Config.DEFAULT_CONNECT_TIMEOUT, config.getConnectionTimeout());
     }
 
     @Test
-    public void shouldKeepSocketTimeoutDefault(){
+    void shouldKeepSocketTimeoutDefault(){
         assertEquals(Config.DEFAULT_SOCKET_TIMEOUT, config.getSocketTimeout());
     }
 
     @Test
-    public void shouldKeepMaxTotalDefault(){
+    void shouldKeepMaxTotalDefault(){
         assertEquals(Config.DEFAULT_MAX_CONNECTIONS, config.getMaxConnections());
     }
 
     @Test
-    public void shouldKeepMaxPerRouteDefault(){
+    void shouldKeepMaxPerRouteDefault(){
         assertEquals(Config.DEFAULT_MAX_PER_ROUTE, config.getMaxPerRoutes());
     }
 
     @Test
-    public void onceTheConfigIsRunningYouCannotChangeConfig(){
+    void onceTheConfigIsRunningYouCannotChangeConfig(){
         config.httpClient(mock(HttpClient.class));
         config.asyncClient(mock(HttpAsyncClient.class));
 
@@ -102,7 +102,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void willNotRebuildIfNotClosableAsyncClient() {
+    void willNotRebuildIfNotClosableAsyncClient() {
         HttpAsyncClient c = mock(HttpAsyncClient.class);
         config.asyncClient(c);
 
@@ -111,12 +111,12 @@ public class ConfigTest {
     }
 
     @Test
-    public void willRebuildIfEmpty() {
+    void willRebuildIfEmpty() {
         assertSame(config.getAsyncClient(), config.getAsyncClient());
     }
 
     @Test
-    public void willRebuildIfClosableAndStopped() {
+    void willRebuildIfClosableAndStopped() {
         CloseableHttpAsyncClient c = mock(CloseableHttpAsyncClient.class);
         when(c.isRunning()).thenReturn(false);
 
@@ -126,7 +126,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void testShutdown() throws IOException {
+    void testShutdown() throws IOException {
         when(asyncClient.isRunning()).thenReturn(true);
 
         Unirest.config()
@@ -142,7 +142,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void settingTTl() {
+    void settingTTl() {
         assertEquals(-1, config.getTTL());
 
         assertEquals(42, config.connectionTTL(42, TimeUnit.MILLISECONDS).getTTL());
@@ -153,7 +153,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void willPowerThroughErrors() throws IOException {
+    void willPowerThroughErrors() throws IOException {
         when(asyncClient.isRunning()).thenReturn(true);
         doThrow(new IOException("1")).when(httpc).close();
         doThrow(new RuntimeException("2")).when(clientManager).close();
@@ -179,7 +179,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void doesNotBombOnNullOptions() throws IOException {
+    void doesNotBombOnNullOptions() throws IOException {
         when(asyncClient.isRunning()).thenReturn(true);
 
         Unirest.config()
@@ -193,7 +193,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void ifTheNextAsyncClientThatIsReturnedIsAlsoOffThrowAnException(){
+    void ifTheNextAsyncClientThatIsReturnedIsAlsoOffThrowAnException(){
         AsyncClient c = mock(AsyncClient.class);
         when(c.isRunning()).thenReturn(false);
         config.asyncClient(g -> c);
@@ -205,7 +205,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void willNotRebuildIfRunning() {
+    void willNotRebuildIfRunning() {
         CloseableHttpAsyncClient c = mock(CloseableHttpAsyncClient.class);
         when(c.isRunning()).thenReturn(true);
 
@@ -215,7 +215,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void provideYourOwnClientBuilder() {
+    void provideYourOwnClientBuilder() {
         Client cli = mock(Client.class);
 
         config.httpClient(c -> cli);
@@ -224,14 +224,14 @@ public class ConfigTest {
     }
 
     @Test
-    public void canSignalForShutdownHook() {
+    void canSignalForShutdownHook() {
         assertFalse(config.shouldAddShutdownHook());
         config.addShutdownHook(true);
         assertTrue(config.shouldAddShutdownHook());
     }
 
     @Test
-    public void canDisableGZipencoding() {
+    void canDisableGZipencoding() {
         assertTrue(config.isRequestCompressionOn());
         config.requestCompression(false);
         assertFalse(config.isRequestCompressionOn());
@@ -239,14 +239,14 @@ public class ConfigTest {
     }
 
     @Test
-    public void canDisableAuthRetry() {
+    void canDisableAuthRetry() {
         assertTrue(config.isAutomaticRetries());
         config.automaticRetries(false);
         assertFalse(config.isAutomaticRetries());
     }
 
     @Test
-    public void provideYourOwnAsyncClientBuilder() {
+    void provideYourOwnAsyncClientBuilder() {
         AsyncClient cli = mock(AsyncClient.class);
         when(cli.isRunning()).thenReturn(true);
 
@@ -256,7 +256,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void canSetProxyViaSetter() {
+    void canSetProxyViaSetter() {
         config.proxy(new Proxy("localhost", 8080, "ryan", "password"));
         assertProxy("localhost", 8080, "ryan", "password");
 
@@ -268,7 +268,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void cannotConfigASslContextIfAKeystoreIsPresent() {
+    void cannotConfigASslContextIfAKeystoreIsPresent() {
         KeyStore store = mock(KeyStore.class);
         SSLContext context = mock(SSLContext.class);
 
@@ -280,7 +280,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void cannotConfigAKeyStoreIfASSLContextIsPresent() {
+    void cannotConfigAKeyStoreIfASSLContextIsPresent() {
         KeyStore store = mock(KeyStore.class);
         SSLContext context = mock(SSLContext.class);
 
@@ -296,14 +296,14 @@ public class ConfigTest {
     }
 
     @Test
-    public void isRunningIfStandardClientIsRunning() {
+    void isRunningIfStandardClientIsRunning() {
         assertFalse(config.isRunning());
         config.getClient();
         assertTrue(config.isRunning());
     }
 
     @Test
-    public void isRunningIfAsyncClientIsRunning() {
+    void isRunningIfAsyncClientIsRunning() {
         assertFalse(config.isRunning());
         config.getAsyncClient();
         assertTrue(config.isRunning());

--- a/unirest/src/test/java/kong/unirest/ContentTypeTest.java
+++ b/unirest/src/test/java/kong/unirest/ContentTypeTest.java
@@ -30,22 +30,22 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ContentTypeTest {
+class ContentTypeTest {
 
     @Test
-    public void contentTypeWithEncoding() {
+    void contentTypeWithEncoding() {
         verifySame(org.apache.http.entity.ContentType.APPLICATION_ATOM_XML,
                 ContentType.APPLICATION_ATOM_XML);
     }
 
     @Test
-    public void imageTypes() {
+    void imageTypes() {
         verifySame(org.apache.http.entity.ContentType.IMAGE_GIF,
                 ContentType.IMAGE_GIF);
     }
 
     @Test
-    public void wildCard() {
+    void wildCard() {
         verifySame(org.apache.http.entity.ContentType.WILDCARD,
                 ContentType.WILDCARD);
     }

--- a/unirest/src/test/java/kong/unirest/CookieParsingTest.java
+++ b/unirest/src/test/java/kong/unirest/CookieParsingTest.java
@@ -30,14 +30,13 @@ import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class CookieParsingTest {
+class CookieParsingTest {
 
     @Test
-    public void parseFull() {
+    void parseFull() {
         Cookie c = new Cookie("color=blue;Path=/get;Domain=localhost;Expires=Sun, 05-Jan-2020 15:00:20 GMT;Max-Age=42;HttpOnly");
         assertEquals("blue", c.getValue());
         assertEquals("localhost", c.getDomain());
@@ -51,37 +50,37 @@ public class CookieParsingTest {
     }
 
     @Test
-    public void alternateDate() {
+    void alternateDate() {
         Cookie c = new Cookie("color=blue;Path=/get;Domain=localhost;Expires=Sun, 05 Jan 2020 15:00:20 GMT;Max-Age=42;HttpOnly");
         assertEquals(ZonedDateTime.of(2020,1,5,15,0,20, 0, ZoneId.of("GMT")),
                 c.getExpiration());
     }
 
     @Test
-    public void parseBackOutToString() {
+    void parseBackOutToString() {
         String v = "color=blue;Path=/get;Domain=localhost;Expires=Sun, 05-Jan-2020 15:00:20 GMT;Max-Age=42;HttpOnly";
         Cookie c = new Cookie(v);
         assertEquals(v, c.toString());
     }
 
     @Test
-    public void sameSite() {
+    void sameSite() {
         String v = "color=blue;SameSite=Strict";
         Cookie c = new Cookie(v);
         assertEquals(Cookie.SameSite.Strict, c.getSameSite());
     }
 
     @Test
-    public void secure() {
+    void secure() {
         String v = "color=blue;Secure";
         Cookie c = new Cookie(v);
-        assertEquals(true, c.isSecure());
+        assertTrue(c.isSecure());
         assertEquals("color=blue;Secure", c.toString());
     }
 
 
     @Test
-    public void matchJettyParsing() {
+    void matchJettyParsing() {
         String s = "_id=A528A0D64DA61CB01241EF6E18E4D675170DDB56CB430000AF58625E920CF940~pl1ZYwDDdoAnfY3RtqZ2Ti1MYOf7Q8jRrFQLneSGK7qQoUX1GHW/xDcqweGyclm5rm/g/YFCV3ohuHoz2oad5M0MX9Ru9V7bFr2s08d1lHxbn39gw71AI+ZVejq5FpMHKBzyjoBGG6NY6xYVTwP9NHo14SY0CXs60k2UTpJsOTNzAHIZaedg7o6R/8qyAQ8GF25K2o773pFLrYtjgKHohkk5ukz/yEGQitq8NgC5hiqX0=; expires=Fri, 06 Mar 2020 16:05:35 GMT; max-age=7200; path=/; domain=xxx.com; HttpOnly";
         CookieCutter cutter = new CookieCutter();
         cutter.addCookieField(s);
@@ -93,14 +92,14 @@ public class CookieParsingTest {
     }
 
     @Test
-    public void futurePropsDontBreak() {
+    void futurePropsDontBreak() {
         String v = "color=blue;TheFuture";
         Cookie c = new Cookie(v);
         assertEquals("color=blue", c.toString());
     }
 
     @Test
-    public void emptyValue() {
+    void emptyValue() {
         String v = "SignOnDefault=; domain=.admin.virginia.edu; path=/; HttpOnly";
         Cookie c = new Cookie(v);
         assertEquals("", c.getValue());
@@ -109,35 +108,35 @@ public class CookieParsingTest {
     }
 
     @Test
-    public void theValieCanBeDoubleQuoted() {
+    void theValieCanBeDoubleQuoted() {
         String v = "SignOnDefault=\" woh \";";
         Cookie c = new Cookie(v);
         assertEquals(" woh ", c.getValue());
     }
 
     @Test
-    public void justEmptyQuotes() {
+    void justEmptyQuotes() {
         String v = "SignOnDefault=\"\";";
         Cookie c = new Cookie(v);
         assertEquals("", c.getValue());
     }
 
     @Test
-    public void valuesCanHaveEquals() {
+    void valuesCanHaveEquals() {
         String v = "SignOnDefault====;";
         Cookie c = new Cookie(v);
         assertEquals("===", c.getValue());
     }
 
     @Test
-    public void justOneQuote() {
+    void justOneQuote() {
         String v = "SignOnDefault=\";";
         Cookie c = new Cookie(v);
         assertEquals("\"", c.getValue());
     }
 
     @Test
-    public void justOneSideOfquotes() {
+    void justOneSideOfquotes() {
         String v = "SignOnDefault=\"foo;";
         Cookie c = new Cookie(v);
         assertEquals("\"foo", c.getValue());

--- a/unirest/src/test/java/kong/unirest/FilePartTest.java
+++ b/unirest/src/test/java/kong/unirest/FilePartTest.java
@@ -32,7 +32,8 @@ import java.io.File;
 import static org.junit.jupiter.api.Assertions.*;
 
 class FilePartTest {
-    private FilePart part = new FilePart(new File("./foo.xml"), "uploadFile", "application/xml");
+
+    private final FilePart part = new FilePart(new File("./foo.xml"), "uploadFile", "application/xml");
 
     @Test
     void filePartsAreFiles() {

--- a/unirest/src/test/java/kong/unirest/HeaderEntryTest.java
+++ b/unirest/src/test/java/kong/unirest/HeaderEntryTest.java
@@ -31,28 +31,28 @@ import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class HeaderEntryTest {
+class HeaderEntryTest {
 
     @Test
-    public void entryNotEqual() {
+    void entryNotEqual() {
         assertNotEquals(entry("foo", "qux"), entry("foo", "bar"));
         assertNotEquals(entry("qux", "bar"), entry("foo", "bar"));
     }
 
     @Test
-    public void entryEqual() {
+    void entryEqual() {
         assertEquals(entry("foo", "bar"), entry("foo", "bar"));
     }
 
     @Test
-    public void entryEqualLambda() {
+    void entryEqualLambda() {
         assertEquals(entry("foo", () -> "bar"), entry("foo", "bar"));
         assertEquals(entry("foo", () -> "bar"), entry("foo", () -> "bar"));
     }
 
     @Test
-    public void entryLambdasCannotBeNull_butMayReturnNull() {
-        assertEquals(null, entry("foo", (Supplier<String>) null).getValue());
+    void entryLambdasCannotBeNull_butMayReturnNull() {
+        assertNull(entry("foo", (Supplier<String>) null).getValue());
     }
 
     private Headers.Entry entry(String key, Supplier<String> value) {

--- a/unirest/src/test/java/kong/unirest/HeadersTest.java
+++ b/unirest/src/test/java/kong/unirest/HeadersTest.java
@@ -33,8 +33,9 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-public class HeadersTest {
-    private String ls  = System.lineSeparator();
+class HeadersTest {
+
+    private final String ls = System.lineSeparator();
 
     @Test
     void canGetHeaders() {

--- a/unirest/src/test/java/kong/unirest/HttpMethodTest.java
+++ b/unirest/src/test/java/kong/unirest/HttpMethodTest.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class HttpMethodTest {
+class HttpMethodTest {
 
     @Test
-    public void equalsTest() {
+    void equalsTest() {
         assertEquals(HttpMethod.valueOf("GET"), HttpMethod.valueOf("GET"));
         assertEquals(HttpMethod.GET, HttpMethod.GET);
         assertNotEquals(HttpMethod.valueOf("GET"), HttpMethod.valueOf("PUT"));
@@ -41,7 +41,7 @@ public class HttpMethodTest {
 
 
     @Test
-    public void notCaseSensative() {
+    void notCaseSensitive() {
         assertEquals(HttpMethod.valueOf("GET"), HttpMethod.valueOf("get"));
     }
 }

--- a/unirest/src/test/java/kong/unirest/InputStreamPartTest.java
+++ b/unirest/src/test/java/kong/unirest/InputStreamPartTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InputStreamPartTest {
-    private InputStreamPart part = new InputStreamPart("uploadFile",
+    private final InputStreamPart part = new InputStreamPart("uploadFile",
             new ByteArrayInputStream(new byte[]{}),
             "application/xml",
             "foo.xml");

--- a/unirest/src/test/java/kong/unirest/JacksonObjectMapperTest.java
+++ b/unirest/src/test/java/kong/unirest/JacksonObjectMapperTest.java
@@ -30,12 +30,12 @@ import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-public class JacksonObjectMapperTest {
+class JacksonObjectMapperTest {
 
-    private JacksonObjectMapper om = new JacksonObjectMapper();
+    private final JacksonObjectMapper om = new JacksonObjectMapper();
 
     @Test
-    public void jsonPatch() throws JSONException {
+    void jsonPatch() throws JSONException {
         JsonPatch patch = new JsonPatch();
         patch.add("/foo", "bar");
         patch.add("/baz", "qux");
@@ -49,7 +49,7 @@ public class JacksonObjectMapperTest {
     }
 
     @Test
-    public void jsonPatchInRequestCapture() throws JSONException {
+    void jsonPatchInRequestCapture() throws JSONException {
         JsonPatch patch = new JsonPatch();
         patch.add("/foo", "bar");
         patch.add("/baz", "qux");

--- a/unirest/src/test/java/kong/unirest/JsonNodeTest.java
+++ b/unirest/src/test/java/kong/unirest/JsonNodeTest.java
@@ -28,32 +28,32 @@ package kong.unirest;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class JsonNodeTest {
+class JsonNodeTest {
 
     @Test
-    public void canParseARegularObject() {
+    void canParseARegularObject() {
         String json = "{\"foo\":\"bar\"}";
         JsonNode node = new JsonNode(json);
-        assertEquals(false, node.isArray());
+        assertFalse(node.isArray());
         assertEquals("bar", node.getObject().getString("foo"));
         assertEquals("bar", node.getArray().getJSONObject(0).getString("foo"));
         assertEquals(json, node.toString());
     }
 
     @Test
-    public void canParseArrayObject() {
+    void canParseArrayObject() {
         String json = "[{\"foo\":\"bar\"}]";
         JsonNode node = new JsonNode(json);
-        assertEquals(true, node.isArray());
+        assertTrue(node.isArray());
         assertEquals("bar", node.getArray().getJSONObject(0).getString("foo"));
-        assertEquals(null, node.getObject());
+        assertNull(node.getObject());
         assertEquals(json, node.toString());
     }
 
     @Test
-    public void nullAndEmptyObjectsResultInEmptyJson() {
+    void nullAndEmptyObjectsResultInEmptyJson() {
         assertEquals("{}", new JsonNode("").toString());
         assertEquals("{}", new JsonNode(null).toString());
     }

--- a/unirest/src/test/java/kong/unirest/JsonObjectMapperTest.java
+++ b/unirest/src/test/java/kong/unirest/JsonObjectMapperTest.java
@@ -41,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class JsonObjectMapperTest {
 
-
     JsonObjectMapper om = new JsonObjectMapper();
 
     @BeforeEach
@@ -133,6 +132,7 @@ class JsonObjectMapperTest {
     }
 
     @Test
+    @SuppressWarnings("MagicConstant")
     void canSerializeCalendar_no_time() {
         Calendar cal = GregorianCalendar.getInstance();
         cal.set(1985, 6, 3, 0, 0, 0);
@@ -260,7 +260,7 @@ class JsonObjectMapperTest {
         assertEquals("{\"test\":\"it's a && b || c + 1!?\"}", res);
     }
 
-    private class TestString {
+    private static class TestString {
         private String test;
     }
     private TestDates getTestDate(String key, Object date) {
@@ -273,6 +273,7 @@ class JsonObjectMapperTest {
         return object.toString();
     }
 
+    @SuppressWarnings("SameParameterValue")
     private TestDates getDate(String date) {
         Date from = Date.from(ZonedDateTime.parse(date).withFixedOffsetZone().toInstant());
         return getDate(from);
@@ -284,6 +285,7 @@ class JsonObjectMapperTest {
         return test;
     }
 
+    @SuppressWarnings("SameParameterValue")
     private TestDates getCalendar(String date) {
         Calendar from = GregorianCalendar.from(ZonedDateTime.parse(date));
         return getCalendar(from);

--- a/unirest/src/test/java/kong/unirest/JsonPatchItemTest.java
+++ b/unirest/src/test/java/kong/unirest/JsonPatchItemTest.java
@@ -33,10 +33,10 @@ import java.util.Set;
 import static kong.unirest.JsonPatchOperation.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JsonPatchItemTest {
+class JsonPatchItemTest {
 
     @Test
-    public void patchOperationsAreUniqueByTheirElements() {
+    void patchOperationsAreUniqueByTheirElements() {
         assertEquals(
                 new JsonPatchItem(add, "/foo", "bar"),
                 new JsonPatchItem(add, "/foo", "bar")
@@ -64,23 +64,23 @@ public class JsonPatchItemTest {
     }
 
     @Test
-    public void testHash() {
-        Set s = Sets.newHashSet(new JsonPatchItem(add, "/foo", "bar"),
+    void testHash() {
+        Set<JsonPatchItem> s = Sets.newHashSet(new JsonPatchItem(add, "/foo", "bar"),
                 new JsonPatchItem(add, "/foo", "bar"));
 
         assertEquals(1, s.size());
     }
 
     @Test
-    public void edgeEquals() {
+    void edgeEquals() {
         JsonPatchItem i = new JsonPatchItem(add, "/foo", "bar");
-        assertTrue(i.equals(i));
-        assertFalse(i.equals(null));
-        assertFalse(i.equals(new Object()));
+        assertEquals(i, i);
+        assertNotEquals(null, i);
+        assertNotEquals(new Object(), i);
     }
 
     @Test
-    public void basicTest() {
+    void basicTest() {
         JsonPatchItem i = new JsonPatchItem(add, "/foo", "bar");
         assertEquals(add, i.getOp());
         assertEquals("/foo", i.getPath());

--- a/unirest/src/test/java/kong/unirest/MockCallback.java
+++ b/unirest/src/test/java/kong/unirest/MockCallback.java
@@ -35,7 +35,7 @@ public class MockCallback<T> implements Callback<T> {
         return new MockCallback<>(test);
     }
 
-    private BddTest test;
+    private final BddTest test;
     private Consumer<HttpResponse<T>> onSuccess = r -> {};
     private Consumer<UnirestException> onFail = f -> {};
     private Runnable onCancel = () -> {};

--- a/unirest/src/test/java/kong/unirest/NotImplemented.java
+++ b/unirest/src/test/java/kong/unirest/NotImplemented.java
@@ -25,5 +25,5 @@
 
 package kong.unirest;
 
-public class NotImplimented extends RuntimeException {
+public class NotImplemented extends RuntimeException {
 }

--- a/unirest/src/test/java/kong/unirest/PagedListTest.java
+++ b/unirest/src/test/java/kong/unirest/PagedListTest.java
@@ -34,13 +34,14 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PagedListTest {
+class PagedListTest {
 
     @Test
-    public void canGetAllTheBodies() {
+    void canGetAllTheBodies() {
         PagedList<String> list = new PagedList<>();
         list.addAll(asList(
                 mkRequest("foo"),
@@ -53,7 +54,7 @@ public class PagedListTest {
     }
 
     @Test
-    public void bodiesMustBeSucessful() {
+    void bodiesMustBeSuccessful() {
         PagedList<String> list = new PagedList<>();
         list.addAll(asList(
                 mkRequest("foo"),
@@ -66,7 +67,7 @@ public class PagedListTest {
     }
 
     @Test
-    public void canProcessSuccessfullResuls() {
+    void canProcessSuccessfulResults() {
         PagedList<String> list = new PagedList<>();
         list.addAll(asList(
                 mkRequest("foo"),
@@ -80,7 +81,7 @@ public class PagedListTest {
     }
 
     @Test
-    public void canProcessFailed() {
+    void canProcessFailed() {
         PagedList<String> list = new PagedList<>();
         list.addAll(asList(
                 mkRequest("foo"),
@@ -90,9 +91,10 @@ public class PagedListTest {
 
         final List<String> processed = new ArrayList<>();
         list.ifFailure(e -> processed.add(e.getBody()));
-        assertEquals(null, processed.get(0));
+        assertNull(processed.get(0));
     }
 
+    @SuppressWarnings("unchecked")
     private HttpResponse<String> mkRequest(String foo) {
         HttpResponse<String> r = mock(HttpResponse.class);
         when(r.getBody()).thenReturn(foo);

--- a/unirest/src/test/java/kong/unirest/PathTest.java
+++ b/unirest/src/test/java/kong/unirest/PathTest.java
@@ -29,16 +29,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PathTest {
+class PathTest {
     @Test
-    public void pathIsTheSameIfUrlIs() {
+    void pathIsTheSameIfUrlIs() {
         Path p = new Path("https://localhost/apples", null);
         Path o = new Path("https://localhost/apples", null);
         assertEquals(p, o);
     }
 
     @Test
-    public void pathsWithDifferentParams() {
+    void pathsWithDifferentParams() {
         String raw = "http://somewhere/fruits/{id}";
         Path q = new Path(raw, null);
         q.param("id", "apple");
@@ -52,7 +52,7 @@ public class PathTest {
     }
 
     @Test
-    public void queryParamsMatter() {
+    void queryParamsMatter() {
         String raw = "http://somewhere/fruits/}";
         Path q = new Path(raw, null);
         q.queryString("id", "apple");
@@ -66,12 +66,12 @@ public class PathTest {
     }
 
     @Test
-    public void canBuildUsingDefaultBase() {
+    void canBuildUsingDefaultBase() {
         assertEquals("http://somwhere/fruit", new Path("/fruit","http://somwhere").toString());
     }
 
     @Test
-    public void willNotAddBaseIfPrimaryPathIsFull() {
+    void willNotAddBaseIfPrimaryPathIsFull() {
         assertEquals("http://somwhere/fruit", new Path("http://somwhere/fruit","http://elsewhere/rocks").toString());
     }
 }

--- a/unirest/src/test/java/kong/unirest/ResponseUtilsTest.java
+++ b/unirest/src/test/java/kong/unirest/ResponseUtilsTest.java
@@ -35,14 +35,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class ResponseUtilsTest {
+class ResponseUtilsTest {
     @Mock
     private Config config;
     @InjectMocks
     TestRawResponse test;
 
     @Test
-    public void getCharsetDefaults() {
+    void getCharsetDefaults() {
         defaultEncoding("UTF-8");
 
         assertEquals("UTF-8", getCharSet(null));
@@ -53,12 +53,12 @@ public class ResponseUtilsTest {
     }
 
     @Test
-    public void contentTypeWhenYouGotIt() {
+    void contentTypeWhenYouGotIt() {
         assertEquals("LATIN-1", getCharSet("Content-Type: text/html; charset=latin-1"));
     }
 
     @Test
-    public void changeTheDefault() {
+    void changeTheDefault() {
         defaultEncoding("KINGON-1");
         assertEquals("KINGON-1", getCharSet(null));
         defaultEncoding("SINDARIN-42");

--- a/unirest/src/test/java/kong/unirest/apache/BaseApacheClientTest.java
+++ b/unirest/src/test/java/kong/unirest/apache/BaseApacheClientTest.java
@@ -26,9 +26,7 @@
 package kong.unirest.apache;
 
 import kong.unirest.Headers;
-import kong.unirest.Proxy;
 import org.apache.http.HttpHost;
-import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class BaseApacheClientTest {
 
-    private BaseApacheClient client;
     private HttpUriRequest request;
     private Headers headers;
 
@@ -51,13 +48,12 @@ class BaseApacheClientTest {
     void setUp() {
         request = new HttpGet();
         headers = new Headers();
-        client = new BaseApacheClient(){};
     }
 
     @Test
     void basicHost() {
         request = new HttpGet(URI.create("http://zombo.com"));
-        HttpHost host = client.determineTarget(request, headers);
+        HttpHost host = BaseApacheClient.determineTarget(request, headers);
         assertEquals("zombo.com", host.getHostName());
         assertNull(host.getAddress());
         assertEquals(-1, host.getPort());
@@ -67,7 +63,7 @@ class BaseApacheClientTest {
     @Test
     void basicHost_withPort() {
         request = new HttpGet(URI.create("http://zombo.com:8080"));
-        HttpHost host = client.determineTarget(request, headers);
+        HttpHost host = BaseApacheClient.determineTarget(request, headers);
         assertEquals("zombo.com", host.getHostName());
         assertNull(host.getAddress());
         assertEquals(8080, host.getPort());
@@ -78,7 +74,7 @@ class BaseApacheClientTest {
     void willIgnoreHostHeaderprovided_IfNotIPv4() {
         headers.add("Host","homestarrunner.com");
         request = new HttpGet(URI.create("http://zombo.com"));
-        HttpHost host = client.determineTarget(request, headers);
+        HttpHost host = BaseApacheClient.determineTarget(request, headers);
         assertEquals("zombo.com", host.getHostName());
     }
 
@@ -86,7 +82,7 @@ class BaseApacheClientTest {
     void willUseHostHeaderprovided_IfNotIPv4() throws UnknownHostException {
         headers.add("Host","homestarrunner.com");
         request = new HttpGet(URI.create("http://127.0.0.1"));
-        HttpHost host = client.determineTarget(request, headers);
+        HttpHost host = BaseApacheClient.determineTarget(request, headers);
         assertEquals("homestarrunner.com", host.getHostName());
         assertEquals(InetAddress.getByName("127.0.0.1"), host.getAddress());
     }
@@ -94,7 +90,7 @@ class BaseApacheClientTest {
     @Test
     void ifUrlIsRelativeThenReturnNull() {
         request = new HttpGet(URI.create("/somewhere"));
-        HttpHost host = client.determineTarget(request, headers);
+        HttpHost host = BaseApacheClient.determineTarget(request, headers);
         assertNull(host);
     }
 }

--- a/unirest/src/test/java/kong/unirest/apache/SecurityConfigTest.java
+++ b/unirest/src/test/java/kong/unirest/apache/SecurityConfigTest.java
@@ -31,10 +31,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SecurityConfigTest {
+class SecurityConfigTest {
 
     @Test
-    public void willTakeConfigIntoAccountWhenCreatingManager() {
+    void willTakeConfigIntoAccountWhenCreatingManager() {
         Config config = new Config().concurrency(88, 42);
 
         SecurityConfig sec = new SecurityConfig(config);

--- a/unirest/src/test/java/kong/unirest/apache/UtilTest.java
+++ b/unirest/src/test/java/kong/unirest/apache/UtilTest.java
@@ -30,28 +30,32 @@ import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.nio.client.HttpAsyncClient;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-public class UtilTest {
+class UtilTest {
 
     @Test
-    public void canCast() {
+    void canCast() {
         Object foo = new Foo(){};
 
-        assertEquals(foo, Util.tryCast(foo, Foo.class).get());
-        assertEquals(false, Util.tryCast("foo", Foo.class).isPresent());
-        assertEquals(false, Util.tryCast(null, Foo.class).isPresent());
-        assertEquals(true, Util.tryCast(new Bar(), Foo.class).isPresent());
+        Optional<Foo> fooCast = Util.tryCast(foo, Foo.class);
+        assertTrue(fooCast.isPresent());
+        assertEquals(foo, fooCast.get());
+        assertFalse(Util.tryCast("foo", Foo.class).isPresent());
+        assertFalse(Util.tryCast(null, Foo.class).isPresent());
+        assertTrue(Util.tryCast(new Bar(), Foo.class).isPresent());
     }
 
     @Test
-    public void canCastAAsyncClient() {
+    void canCastAAsyncClient() {
         HttpAsyncClient build = HttpAsyncClientBuilder.create().build();
 
-        assertEquals(true, Util.tryCast(build, CloseableHttpAsyncClient.class).isPresent());
+        assertTrue(Util.tryCast(build, CloseableHttpAsyncClient.class).isPresent());
     }
 
-    public abstract class Foo {}
+    public abstract static class Foo {}
 
     public class Bar extends Foo {}
 }

--- a/unirest/src/test/java/kong/unirest/json/JSONArrayTest.java
+++ b/unirest/src/test/java/kong/unirest/json/JSONArrayTest.java
@@ -34,6 +34,7 @@ import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableMap.of;
@@ -44,25 +45,25 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JSONArrayTest {
+class JSONArrayTest {
 
     @Test
-    public void nullForSoManyReasonsWhenZipping() {
+    void nullForSoManyReasonsWhenZipping() {
         JSONArray array = new JSONArray();
-        assertNull(array.toJSONObject(new JSONArray(Arrays.asList("foo"))));
+        assertNull(array.toJSONObject(new JSONArray(Collections.singletonList("foo"))));
         array.put(42L);
         assertNull(array.toJSONObject(null));
         assertNull(array.toJSONObject(new JSONArray()));
     }
 
     @Test
-    public void serializeNulls() {
+    void serializeNulls() {
         JSONArray obj = new JSONArray("[1,null]");
         assertEquals("[1,null]", obj.toString());
     }
 
     @Test
-    public void exeptionWhileZippingForNull() {
+    void exeptionWhileZippingForNull() {
         JSONArray values = new JSONArray(Arrays.asList(1, "foo", false));
         JSONArray names = new JSONArray();
         names.put((String)null);
@@ -73,7 +74,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void zipAnArray() {
+    void zipAnArray() {
         JSONArray values = new JSONArray(Arrays.asList(1, "foo", false));
         JSONArray names = new JSONArray(Arrays.asList("one", "two", "three", "four"));
         JSONObject zipped = values.toJSONObject(names);
@@ -83,7 +84,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void putObject() {
+    void putObject() {
         JSONArray array  = new JSONArray();
         array.put(new Foo("fooooo"));
         array.put((Object)"abc");
@@ -93,14 +94,9 @@ public class JSONArrayTest {
         assertEquals("abc", array.get(1));
         assertEquals("{\"foo\":\"bar\"}", array.get(2).toString());
     }
-    @Test
-    public void putSomeGenericObject() {
-        JSONArray array = new JSONArray();
-
-    }
 
     @Test
-    public void simpleConvert() {
+    void simpleConvert() {
         String str = "[{\"foo\": \"bar\"}, {\"baz\": 42}]";
 
         JSONArray array = new JSONArray(str);
@@ -111,7 +107,8 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void putObjectAtElement() {
+    @SuppressWarnings("ConstantConditions")
+    void putObjectAtElement() {
         Object nul = null;
         Object num = 42;
         Object str = "hi";
@@ -136,7 +133,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void numbers() {
+    void numbers() {
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put((Number)33));
         obj.put("nan");
@@ -146,12 +143,12 @@ public class JSONArrayTest {
         assertNotType(() -> obj.getNumber(1), "JSONArray[1] is not a number.");
 
         assertEquals(33, obj.optNumber(0));
-        assertEquals(66.6d, obj.optNumber(1, (Number)66.6d));
-        assertEquals(null, obj.optNumber(5));
+        assertEquals(66.6d, obj.optNumber(1, 66.6d));
+        assertNull(obj.optNumber(5));
     }
 
     @Test
-    public void doubles() {
+    void doubles() {
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(33.5d));
         obj.put("nan");
@@ -166,7 +163,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void floats() {
+    void floats() {
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(33.5f));
         obj.put("nan");
@@ -181,7 +178,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void longs() {
+    void longs() {
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(33L));
         obj.put("nan");
@@ -196,22 +193,22 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void bools() {
+    void bools() {
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(true));
         obj.put("nan");
 
-        assertEquals(true, obj.getBoolean(0));
+        assertTrue(obj.getBoolean(0));
         assertNotFound(() -> obj.getBoolean(5));
         assertNotType(() -> obj.getBoolean(1), "JSONArray[1] is not a boolean.");
 
-        assertEquals(true, obj.optBoolean(0));
-        assertEquals(true, obj.optBoolean(5, true));
-        assertEquals(false, obj.optBoolean(5));
+        assertTrue(obj.optBoolean(0));
+        assertTrue(obj.optBoolean(5, true));
+        assertFalse(obj.optBoolean(5));
     }
 
     @Test
-    public void ints() {
+    void ints() {
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(33));
         obj.put("nan");
@@ -226,7 +223,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void bigInts() {
+    void bigInts() {
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(BigInteger.valueOf(33)));
         obj.put("nan");
@@ -239,7 +236,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void bigDecimal() {
+    void bigDecimal() {
         BigDecimal value = BigDecimal.valueOf(33.5);
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(value));
@@ -253,21 +250,21 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void strings() {
+    void strings() {
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put("cheese"));
         obj.put(45);
 
         assertEquals("cheese", obj.getString(0));
         assertNotFound(() -> obj.getString(5));
-        assertEquals(obj.getString(1), "45");
+        assertEquals("45", obj.getString(1));
         assertEquals("cheese", obj.optString(0));
         assertEquals("logs", obj.optString(5, "logs"));
         assertEquals("", obj.optString(5));
     }
 
     @Test
-    public void jsonObjects() throws Exception {
+    void jsonObjects() throws Exception {
         JSONObject subObj = new JSONObject("{\"derp\": 42}");
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(subObj));
@@ -277,11 +274,11 @@ public class JSONArrayTest {
         assertNotFound(() -> obj.getJSONObject(5));
         assertNotType(() -> obj.getJSONObject(1), "JSONArray[1] is not a JSONObject.");
         assertEqualJson(subObj, obj.optJSONObject(0));
-        assertEquals(null, obj.optJSONObject(5));
+        assertNull(obj.optJSONObject(5));
     }
 
     @Test
-    public void jsonArrays() throws Exception {
+    void jsonArrays() throws Exception {
         JSONArray subObj = new JSONArray("[42]");
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(subObj));
@@ -291,11 +288,11 @@ public class JSONArrayTest {
         assertNotFound(() -> obj.getJSONArray(5));
         assertNotType(() -> obj.getJSONArray(1), "JSONArray[1] is not a JSONArray.");
         assertEqualJson(subObj, obj.optJSONArray(0));
-        assertEquals(null, obj.optJSONArray(5));
+        assertNull(obj.optJSONArray(5));
     }
 
     @Test
-    public void enums() {
+    void enums() {
         JSONArray obj = new JSONArray();
         assertSame(obj, obj.put(fruit.orange));
         obj.put("nan");
@@ -304,11 +301,11 @@ public class JSONArrayTest {
         assertNotType(() -> obj.getEnum(fruit.class, 1), "JSONArray[1] is not an enum of type \"fruit\".");
         assertEquals(fruit.orange, obj.optEnum(fruit.class, 0));
         assertEquals(fruit.apple, obj.optEnum(fruit.class, 1, fruit.apple));
-        assertEquals(null, obj.optEnum(fruit.class, 5));
+        assertNull(obj.optEnum(fruit.class, 5));
     }
 
     @Test
-    public void joinArray() {
+    void joinArray() {
         String str = "[33.5, 42, \"foo\", true, apple]";
 
         JSONArray array = new JSONArray(str);
@@ -317,7 +314,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void toStringIt() {
+    void toStringIt() {
         String str = "[33.5, 42, \"foo\", true, apple]";
 
         JSONArray array = new JSONArray(str);
@@ -326,7 +323,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void toStringItIndent() {
+    void toStringItIndent() {
         String str = "[33.5, 42, \"foo\", true, apple]";
 
         JSONArray array = new JSONArray(str);
@@ -341,7 +338,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void rawGet() {
+    void rawGet() {
         JSONArray array = new JSONArray(asList(
                 33.457848383,
                 1,
@@ -357,7 +354,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void arraysOfArrays() {
+    void arraysOfArrays() {
         String str = "[[1,2,3],[6,7,8]]";
 
         JSONArray array = new JSONArray(str);
@@ -367,7 +364,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void writer() {
+    void writer() {
         String str = "[1,2,3]";
 
         JSONArray array = new JSONArray(str);
@@ -380,7 +377,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void writerIndent() {
+    void writerIndent() {
         String str = "[1,2,3]";
 
         JSONArray array = new JSONArray(str);
@@ -397,7 +394,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void remove() {
+    void remove() {
         JSONObject o = new JSONObject(of("foo","bar"));
         JSONArray array = new JSONArray(asList(1, o));
 
@@ -405,17 +402,17 @@ public class JSONArrayTest {
         assertTrue(remove instanceof JSONObject);
         assertEquals(o, remove);
         assertEquals(1, array.length());
-        assertEquals(null, array.remove(55));
+        assertNull(array.remove(55));
     }
 
     @Test
-    public void removeMissingIndex() {
+    void removeMissingIndex() {
         JSONArray array = new JSONArray("[1,2,3]");
         assertNull(array.remove(55));
     }
 
     @Test
-    public void putSimple() {
+    void putSimple() {
         JSONArray array = new JSONArray();
         array.put(1);
         array.put(Long.MAX_VALUE);
@@ -440,7 +437,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void putByIndex() {
+    void putByIndex() {
         JSONArray array = new JSONArray();
         array.put(5, fruit.pear);
         array.put(0, 1);
@@ -465,14 +462,14 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void query() {
+    void query() {
         JSONArray obj = new JSONArray("[{\"a\":{\"b\": 42}}]");
         assertEquals(42, obj.query("/0/a/b"));
     }
 
     @Test
-    public void putCollection() {
-        List ints = asList(1, 1, 2, 3);
+    void putCollection() {
+        List<Integer> ints = asList(1, 1, 2, 3);
         JSONArray array = new JSONArray();
         array.put(ints);
 
@@ -481,7 +478,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void constructCollection() {
+    void constructCollection() {
         List<Integer> ints = asList(1, 1, 2, 3);
         JSONArray array = new JSONArray(ints);
 
@@ -490,7 +487,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void constructArray() {
+    void constructArray() {
         List<Integer> ints = asList(1, 1, 2, 3);
         JSONArray array = new JSONArray(ints.toArray());
 
@@ -499,14 +496,14 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void constructArrayError() {
+    void constructArrayError() {
         assertException(()-> new JSONArray(new Object()),
                 JSONException.class,
                 "JSONArray initial value should be a string or collection or array.");
     }
 
     @Test
-    public void nullMembers() {
+    void nullMembers() {
         JSONArray array = new JSONArray();
         array.put("foo");
         array.put((Object) null);
@@ -518,7 +515,7 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void puttingSomeRandoObjectWillResultInString() {
+    void puttingSomeRandoObjectWillResultInString() {
         JSONArray array = new JSONArray();
         array.put(new Fudge());
 
@@ -526,7 +523,8 @@ public class JSONArrayTest {
     }
 
     @Test
-    public void iterateOverArray() {
+    @SuppressWarnings("SuspiciousMethodCalls")
+    void iterateOverArray() {
         List<Integer> list = asList(1, 2, 3, 4);
         JSONArray array = new JSONArray(list);
         for(Object i : array){
@@ -542,7 +540,7 @@ public class JSONArrayTest {
         assertNotType(exRunnable, "JSONArray[5] not found.");
     }
 
-    public class Fudge {
+    public static class Fudge {
         public String foo = "bar";
 
         public String toString(){
@@ -550,7 +548,7 @@ public class JSONArrayTest {
         }
     }
 
-    public enum fruit {orange, apple, pear;}
+    public enum fruit {orange, apple, pear}
 
 }
 

--- a/unirest/src/test/java/kong/unirest/json/JSONObjectTest.java
+++ b/unirest/src/test/java/kong/unirest/json/JSONObjectTest.java
@@ -44,10 +44,10 @@ import static java.util.Arrays.asList;
 import static kong.unirest.TestUtil.assertException;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JSONObjectTest {
+class JSONObjectTest {
 
     @Test
-    public void isEmpty() {
+    void isEmpty() {
         JSONObject o = new JSONObject();
         assertTrue(o.isEmpty());
         o.put("foo", "bar");
@@ -55,7 +55,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void isNull() {
+    void isNull() {
         JSONObject o = new JSONObject();
         assertTrue(o.isNull("foo"));
         o.put("foo", (Object)null);
@@ -65,14 +65,14 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void contructInvalid() {
+    void contructInvalid() {
         TestUtil.assertException(() -> new JSONObject("foo"),
                 JSONException.class,
                 "Invalid JSON");
     }
 
     @Test
-    public void simpleConvert() {
+    void simpleConvert() {
         String str = "{\"foo\": {\"baz\": 42}}";
 
         JSONObject obj = new JSONObject(str);
@@ -83,7 +83,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void doubles() {
+    void doubles() {
         JSONObject obj = new JSONObject();
         obj.put("key", 33.5d);
         obj.put("not", "nan");
@@ -99,7 +99,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void nullsAreSerialized() {
+    void nullsAreSerialized() {
         JSONObject obj = new JSONObject("{\"key1\": \"value\", \"key2\": null}");
 
         assertEquals("{\"key1\":\"value\",\"key2\":null}", obj.toString());
@@ -112,7 +112,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void nullsAreSerializedOnPretty() {
+    void nullsAreSerializedOnPretty() {
         JSONObject obj = new JSONObject("{\"key1\": \"value\", \"key2\": null}");
 
         assertEquals("{\n" +
@@ -122,7 +122,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void floats() {
+    void floats() {
         JSONObject obj = new JSONObject();
         obj.put("key", 33.5f);
         obj.put("not", "nan");
@@ -138,7 +138,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void longs() {
+    void longs() {
         JSONObject obj = new JSONObject();
         obj.put("key", Long.MAX_VALUE);
         obj.put("not", "nan");
@@ -154,23 +154,23 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void booleans() {
+    void booleans() {
         JSONObject obj = new JSONObject();
         obj.put("key", true);
         obj.put("not", "nan");
 
-        assertEquals(true, obj.getBoolean("key"));
+        assertTrue(obj.getBoolean("key"));
         assertNotFound(() -> obj.getBoolean("boo"));
         assertJSONEx(() -> obj.getBoolean("not"), "JSONObject[\"not\"] is not a boolean.");
         isTypeAndValue(true, Boolean.class, obj.get("key"));
 
-        assertEquals(true, obj.optBoolean("key"));
-        assertEquals(true, obj.optBoolean("boo", true));
-        assertEquals(false, obj.optBoolean("boo"));
+        assertTrue(obj.optBoolean("key"));
+        assertTrue(obj.optBoolean("boo", true));
+        assertFalse(obj.optBoolean("boo"));
     }
 
     @Test
-    public void ints() {
+    void ints() {
         JSONObject obj = new JSONObject();
         obj.put("key", 33);
         obj.put("not", "nan");
@@ -185,7 +185,7 @@ public class JSONObjectTest {
         assertEquals(0, obj.optInt("boo"));
     }
     @Test
-    public void numbers() {
+    void numbers() {
         Number tt =  33;
         JSONObject obj = new JSONObject();
         obj.put("key", tt);
@@ -202,7 +202,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void bigInts() {
+    void bigInts() {
         JSONObject obj = new JSONObject();
         obj.put("key", BigInteger.valueOf(33));
         obj.put("not", "nan");
@@ -216,7 +216,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void bigDecimal() {
+    void bigDecimal() {
         BigDecimal value = BigDecimal.valueOf(33.5);
         JSONObject obj = new JSONObject();
         obj.put("key", value);
@@ -231,7 +231,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void strings() {
+    void strings() {
         JSONObject obj = new JSONObject();
         obj.put("key", "cheese");
         obj.put("not", 45);
@@ -246,7 +246,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void jsonObjects() throws Exception {
+    void jsonObjects() throws Exception {
         JSONObject subObj = new JSONObject("{\"derp\": 42}");
         JSONObject obj = new JSONObject();
         obj.put("key", subObj);
@@ -256,12 +256,12 @@ public class JSONObjectTest {
         assertNotFound(() -> obj.getJSONObject("boo"));
         assertJSONEx(() -> obj.getJSONObject("not"), "JSONObject[\"not\"] is not a JSONObject.");
         assertEqualJson(subObj, obj.optJSONObject("key"));
-        assertEquals(null, obj.optJSONObject("boo"));
+        assertNull(obj.optJSONObject("boo"));
         assertTrue(subObj.similar(obj.get("key")));
     }
 
     @Test
-    public void jsonArrays() throws Exception {
+    void jsonArrays() throws Exception {
         JSONArray subObj = new JSONArray("[42]");
         JSONObject obj = new JSONObject();
         obj.put("key", subObj);
@@ -271,12 +271,12 @@ public class JSONObjectTest {
         assertNotFound(() -> obj.getJSONArray("boo"));
         assertJSONEx(() -> obj.getJSONArray("not"), "JSONObject[\"not\"] is not a JSONArray.");
         assertEqualJson(subObj, obj.optJSONArray("key"));
-        assertEquals(null, obj.optJSONArray("boo"));
+        assertNull(obj.optJSONArray("boo"));
         assertTrue(subObj.similar(obj.get("key")));
     }
 
     @Test
-    public void enums() {
+    void enums() {
         JSONObject obj = new JSONObject();
         obj.put("key", fruit.orange);
         obj.put("not", "nan");
@@ -285,12 +285,12 @@ public class JSONObjectTest {
         assertJSONEx(() -> obj.getEnum(fruit.class, "not"), "JSONObject[\"not\"] is not an enum of type \"fruit\".");
         assertEquals(fruit.orange, obj.optEnum(fruit.class, "key"));
         assertEquals(fruit.apple, obj.optEnum(fruit.class, "boo", fruit.apple));
-        assertEquals(null, obj.optEnum(fruit.class, "boo"));
+        assertNull(obj.optEnum(fruit.class, "boo"));
         isTypeAndValue(obj.get("key"), String.class, "orange");
     }
 
     @Test
-    public void toStringIt() {
+    void toStringIt() {
         String str = "{\"foo\": 42}";
 
         JSONObject obj = new JSONObject(str);
@@ -299,7 +299,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void toStringItIndent() {
+    void toStringItIndent() {
         String str = "{\"foo\": 42, \"bar\": true}";
 
         JSONObject obj = new JSONObject(str);
@@ -311,18 +311,18 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void objProperties() {
+    void objProperties() {
         String str = "{\"foos\": [6,7,8]}";
 
         JSONObject obj = new JSONObject(str);
 
         assertEquals(7, obj.getJSONArray("foos").get(1));
         assertEquals(7, obj.optJSONArray("foos").get(1));
-        assertEquals(null, obj.optJSONArray("bars"));
+        assertNull(obj.optJSONArray("bars"));
     }
 
     @Test
-    public void writer() {
+    void writer() {
         String str = "{\"foo\":42}";
 
         JSONObject obj = new JSONObject(str);
@@ -335,7 +335,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void writerIndent() {
+    void writerIndent() {
         String str = "{\"foo\": 42, \"bar\": true}";
 
         JSONObject obj = new JSONObject(str);
@@ -351,7 +351,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void remove() {
+    void remove() {
         JSONObject obj = new JSONObject("{\"foo\": 42, \"bar\": true}");
         assertEquals(42, obj.remove("foo"));
         assertNull(obj.remove("nothing"));
@@ -359,7 +359,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void removeAThingThatDoesntExist() {
+    void removeAThingThatDoesntExist() {
         JSONObject obj = new JSONObject();
         obj.remove("foo");
 
@@ -367,7 +367,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void putReplace() {
+    void putReplace() {
         JSONObject obj = new JSONObject("{\"bar\": 42}");
         assertEquals(42, obj.get("bar"));
         assertSame(obj, obj.put("bar", 33));
@@ -376,14 +376,14 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void accumulateDoesNotCreate() {
+    void accumulateDoesNotCreate() {
         JSONObject obj = new JSONObject();
         assertSame(obj, obj.accumulate("bar", 42));
         assertEquals(0, obj.length());
     }
 
     @Test
-    public void accumulate() {
+    void accumulate() {
         JSONObject obj = new JSONObject("{\"bar\": 42}");
         assertSame(obj, obj.accumulate("bar", 33));
         assertEquals(2, obj.getJSONArray("bar").length());
@@ -392,14 +392,14 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void accumulateNullKey() {
+    void accumulateNullKey() {
         assertException(() -> new JSONObject().accumulate(null, "hi"),
                 NullPointerException.class,
                 "Null key.");
     }
 
     @Test
-    public void append() {
+    void append() {
         JSONObject obj = new JSONObject();
         assertSame(obj, obj.append("bar", 42));
         obj.append("bar", 33);
@@ -409,14 +409,14 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void appendNullKey() {
+    void appendNullKey() {
         assertException(() -> new JSONObject().append(null, "hi"),
                 NullPointerException.class,
                 "Null key.");
     }
 
     @Test
-    public void appendToNotAnArrary() {
+    void appendToNotAnArrary() {
         JSONObject obj = new JSONObject();
         assertSame(obj, obj.put("bar", "not"));
         assertException(() -> obj.append("bar", 33),
@@ -425,7 +425,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void increment() {
+    void increment() {
         JSONObject obj = new JSONObject();
         assertSame(obj, obj.increment("cool-beans"));
         assertEquals(1, obj.get("cool-beans"));
@@ -436,7 +436,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void incrementDouble() {
+    void incrementDouble() {
         JSONObject obj = new JSONObject();
         assertSame(obj, obj.put("cool-beans", 1.5));
         obj.increment("cool-beans");
@@ -445,7 +445,7 @@ public class JSONObjectTest {
 
 
     @Test
-    public void putOnce() {
+    void putOnce() {
         JSONObject obj = new JSONObject();
         assertSame(obj, obj.putOnce("foo", "bar"));
         assertJSONEx(() -> obj.putOnce("foo", "baz"), "Duplicate key \"foo\"");
@@ -453,7 +453,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void optPut() {
+    void optPut() {
         JSONObject obj = new JSONObject();
         assertSame(obj, obj.putOpt("foo", "bar"));
         obj.putOpt(null, "bar");
@@ -464,7 +464,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void keySet() {
+    void keySet() {
         JSONObject obj = new JSONObject();
         obj.put("one", "a");
         obj.put("two", "b");
@@ -474,7 +474,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void similar() {
+    void similar() {
         JSONObject obj1 = new JSONObject("{\"foo\":42}");
         JSONObject obj2 = new JSONObject("{\"foo\":42}");
         assertTrue(obj1.similar(obj2));
@@ -483,23 +483,23 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void query() {
+    void query() {
         JSONObject obj = new JSONObject("{\"a\":{\"b\": 42}}");
         assertEquals(42, obj.query("/a/b"));
     }
 
     @Test
-    public void maps() {
+    void maps() {
         JSONObject obj = new JSONObject("{\"foo\": {\"bar\": 42}, \"baz\": 55}");
 
-        Map map = obj.toMap();
+        Map<String, Object> map = obj.toMap();
         assertEquals(55.0, map.get("baz"));
         JSONObject sub = (JSONObject) obj.get("foo");
         assertEquals(42, sub.get("bar"));
     }
 
     @Test
-    public void names() {
+    void names() {
         JSONObject obj = new JSONObject(of("foo", 1, "bar", 2, "baz", 3));
         JSONArray names = obj.names();
         assertEquals(
@@ -509,7 +509,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void toJSONArray() {
+    void toJSONArray() {
         JSONObject o = new JSONObject(of("foo","bar","baz",42));
 
         assertNull(o.toJSONArray(new JSONArray()));
@@ -522,21 +522,22 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void putCollection() {
+    void putCollection() {
         JSONObject o = new JSONObject();
         o.put("foo", asList(1,2,3));
         assertEquals("{\"foo\":[1,2,3]}", o.toString());
     }
 
     @Test
-    public void putObjectAsMap() {
+    void putObjectAsMap() {
         JSONObject o = new JSONObject();
         o.put("foo", of("baz", 42));
         assertEquals("{\"foo\":{\"baz\":42}}", o.toString());
     }
 
     @Test
-    public void stringToValue() {
+    @SuppressWarnings("ConstantConditions")
+    void stringToValue() {
         assertSame(JSONObject.NULL, JSONObject.stringToValue("null"));
         assertEquals(true, JSONObject.stringToValue("true"));
         assertEquals(false, JSONObject.stringToValue("false"));
@@ -549,19 +550,19 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void quote() {
+    void quote() {
         assertEquals("\"\\\"foo\\\"hoo\"", JSONObject.quote("\"foo\"hoo"));
     }
 
     @Test
-    public void quoteWriter() throws IOException {
+    void quoteWriter() throws IOException {
         StringWriter w = new StringWriter();
         Writer quote = JSONObject.quote("\"foo\"hoo", w);
         assertEquals("\"\\\"foo\\\"hoo\"", quote.toString());
     }
 
     @Test
-    public void wrapPrimitives() throws IOException {
+    void wrapPrimitives() {
         assertEquals(42, JSONObject.wrap(42));
         assertEquals(42.5, JSONObject.wrap(42.5));
         assertSame(JSONObject.NULL, JSONObject.wrap(null));
@@ -569,7 +570,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void wrapObjects() throws IOException {
+    void wrapObjects() {
         assertTrue(new JSONArray(asList(1,2,3)).similar(JSONObject.wrap(asList(1,2,3))));
         assertTrue(new JSONArray(asList(1,2,3)).similar(JSONObject.wrap(new int[]{1,2,3})));
         assertTrue(new JSONObject(of("f",1)).similar(JSONObject.wrap(of("f",1))));
@@ -577,19 +578,19 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void doubleToString() {
+    void doubleToString() {
         assertEquals("42", JSONObject.doubleToString(42));
         assertEquals("42.5643", JSONObject.doubleToString(42.5643));
     }
 
     @Test
-    public void numberToString() {
+    void numberToString() {
         assertEquals("42", JSONObject.numberToString(42));
         assertEquals("42.5643", JSONObject.numberToString(42.5643f));
     }
 
     @Test
-    public void valueToString() {
+    void valueToString() {
         assertEquals("null", JSONObject.valueToString(null));
         assertEquals("42", JSONObject.valueToString(42));
         assertEquals("42.5643", JSONObject.valueToString(42.5643f));
@@ -601,7 +602,7 @@ public class JSONObjectTest {
     }
 
     @Test
-    public void getNames() {
+    void getNames() {
         assertArrayEquals(null, JSONObject.getNames(new JSONObject()));
         assertArrayEquals(new String[]{"a","b"}, JSONObject.getNames(new JSONObject(of("a",1,"b",2))));
     }
@@ -623,7 +624,7 @@ public class JSONObjectTest {
         assertTrue(type.isInstance(o));
     }
 
-    public enum fruit {orange, apple, pear;}
+    public enum fruit {orange, apple}
 
     public static class ImmaJson implements JSONString {
 

--- a/unirest/src/test/java/kong/unirest/json/JSONPointerTest.java
+++ b/unirest/src/test/java/kong/unirest/json/JSONPointerTest.java
@@ -32,136 +32,137 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class JSONPointerTest {
+class JSONPointerTest {
     // https://tools.ietf.org/html/rfc6901
-    private static String RFC_TEST = TestUtil.getResource("JSON_POINTER_REF.json");
-    private JSONObject obj = new JSONObject(RFC_TEST);
+    private static final String RFC_TEST = TestUtil.getResource("JSON_POINTER_REF.json");
+    private final JSONObject obj = new JSONObject(RFC_TEST);
 
     @Test
-    public void nullQuery() {
+    void nullQuery() {
         TestUtil.assertException(() -> obj.query((String)null),
                 NullPointerException.class,
                 "pointer cannot be null");
     }
 
     @Test
-    public void invalidPathQuery() {
+    void invalidPathQuery() {
         TestUtil.assertException(() -> obj.query("foo"),
                 IllegalArgumentException.class,
                 "a JSON pointer should start with '/' or '#/'");
     }
 
     @Test
-    public void invalidPathQuery_downpath() {
+    void invalidPathQuery_downpath() {
         TestUtil.assertException(() -> obj.query("/shwoop/dedoop"),
                 JSONPointerException.class,
                 "Path Segment Missing: shwoop");
     }
 
     @Test
-    public void arrayPartThatDoesNotExist() {
+    void arrayPartThatDoesNotExist() {
         TestUtil.assertException(() -> obj.query("/foo/5"),
                 JSONPointerException.class,
                 "index 5 is out of bounds - the array has 2 elements");
     }
 
     @Test
-    public void referenceAnArrayAsAThing() {
+    void referenceAnArrayAsAThing() {
         TestUtil.assertException(() -> obj.query("/foo/bar"),
                 JSONPointerException.class,
                 "bar is not an array index");
     }
 
     @Test
-    public void constructorMayNotTakeNull() {
+    @SuppressWarnings("RedundantCast")
+    void constructorMayNotTakeNull() {
         TestUtil.assertException(() -> new JSONPointer((String) null),
                 NullPointerException.class,
                 "pointer cannot be null");
     }
 
     @Test
-    public void toStringReturnsOriginalString() {
+    void toStringReturnsOriginalString() {
         assertEquals("/foo/g~0h/baz", new JSONPointer("/foo/g~h/baz").toString());
         assertEquals("/foo/g~0h/baz", JSONPointer.compile("/foo/g~h/baz").toString());
     }
 
     @Test
-    public void canGetAsURIFragmanet() {
+    void canGetAsURIFragmanet() {
         assertEquals("#/foo/g%7Eh/baz", new JSONPointer("/foo/g~h/baz").toURIFragment());
     }
 
     @Test
-    public void elementInObjectDoesNotExist() {
+    void elementInObjectDoesNotExist() {
         assertNull(obj.query("/derpa"));
     }
 
     @Test
-    public void testRef_all() throws Exception {
+    void testRef_all() throws Exception {
         assertQueryJson(RFC_TEST, "");
     }
 
     @Test
-    public void testRef_Array() throws Exception {
+    void testRef_Array() throws Exception {
         assertQueryJson("[\"bar\", \"baz\"]", "/foo");
     }
 
     @Test
-    public void testRef_ArrayZero() {
+    void testRef_ArrayZero() {
         assertEquals("bar", obj.query("/foo/0").toString());
     }
 
     @Test
-    public void testRef_Slash() {
+    void testRef_Slash() {
         assertEquals(0, obj.query("/"));
     }
 
     @Test
-    public void testRef_ab() {
+    void testRef_ab() {
         assertEquals(1, obj.query("/a~1b"));
     }
 
     @Test
-    public void testRef_cd() {
+    void testRef_cd() {
         assertEquals(2, obj.query("/c%d"));
     }
 
     @Test
-    public void testRef_ef() {
+    void testRef_ef() {
         assertEquals(3, obj.query("/e^f"));
     }
 
     @Test
-    public void testRef_gh() {
+    void testRef_gh() {
         assertEquals(4, obj.query("/g|h"));
     }
 
     @Test
-    public void testRef_ij() {
+    void testRef_ij() {
         assertEquals(5, obj.query("/i\\j"));
     }
 
     @Test
-    public void testRef_kl() {
+    void testRef_kl() {
         assertEquals(6, obj.query("/k\"l"));
     }
 
     @Test
-    public void testRef_space() {
+    void testRef_space() {
         assertEquals(7, obj.query("/ "));
     }
 
     @Test
-    public void testRef_mn() {
+    void testRef_mn() {
         assertEquals(8, obj.query("/m~0n"));
     }
 
     @Test
-    public void letsGoDeep() {
+    void letsGoDeep() {
         assertEquals(true, obj.query("/cucu/0/banana/pants"));
     }
 
     @Test
-    public void builder(){
+    void builder(){
         JSONPointer pointer = JSONPointer
                 .builder()
                 .append("foo")


### PR DESCRIPTION
When working on a previous pull request I noticed that a-lot of unit test are still using the old way of declaration.
Even though it is not wrong, but it is not required anymore for Junit5. I wanted to give a shot to refactor all the unit tests and when working on it I also simplified some assertions, removed unused imports and fixed some typo's