### PR TITLE
Fix useSystemProperties

### DIFF
--- a/unirest/src/main/java/kong/unirest/Config.java
+++ b/unirest/src/main/java/kong/unirest/Config.java
@@ -65,7 +65,7 @@ public class Config {
     private int maxPerRoute;
     private boolean followRedirects;
     private boolean cookieManagement;
-    private boolean useSystemProperties;
+    private boolean useSystemProperties = true;
     private String defaultResponseEncoding = StandardCharsets.UTF_8.name();
     private Function<Config, AsyncClient> asyncBuilder;
     private Function<Config, Client> clientBuilder;

--- a/unirest/src/main/java/kong/unirest/apache/ApacheClient.java
+++ b/unirest/src/main/java/kong/unirest/apache/ApacheClient.java
@@ -57,8 +57,7 @@ public class ApacheClient extends BaseApacheClient implements Client {
                 .setDefaultRequestConfig(RequestOptions.toRequestConfig(config))
                 .setDefaultCredentialsProvider(toApacheCreds(config.getProxy()))
                 .setConnectionManager(manager)
-                .evictIdleConnections(30, TimeUnit.SECONDS)
-                .useSystemProperties();
+                .evictIdleConnections(30, TimeUnit.SECONDS);
 
         setOptions(cb);
         client = cb.build();


### PR DESCRIPTION
Previously the value set with Config.useSystemProperties(boolean) was overriden. This pull request removes the call to HttpClientBuilder.useSystemProperties() from the ApacheClient constructor, so it is only called when the appropriate config is set.
Also set the default value of useSystemProperties to true in order to not break behavior from previous versions.