### PR TITLE
Remove redundant dependencies

### DIFF
--- a/bad-maven-test/pom.xml
+++ b/bad-maven-test/pom.xml
@@ -26,6 +26,32 @@
             <artifactId>unirest-java</artifactId>
             <version>2.3.05</version>
             <classifier>standalone</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpasyncclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpmime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
@ryber Hi, I am a user of project **_com.kong:bad-maven-test:2.3.00-SNAPSHOT_**. I found that its pom file introduced **_10_** dependencies. However, among them, **_8_** libraries (**_80%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_com.kong:bad-maven-test:2.3.00-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
commons-logging:commons-logging:jar:1.2:compile
org.apache.httpcomponents:httpcore:jar:4.4.11:compile
commons-codec:commons-codec:jar:1.11:compile
org.apache.httpcomponents:httpmime:jar:4.5.8:compile
org.apache.httpcomponents:httpasyncclient:jar:4.1.4:compile
org.apache.httpcomponents:httpclient:jar:4.5.8:compile
org.apache.httpcomponents:httpcore-nio:jar:4.4.10:compile
org.json:json:jar:20180813:compile
</code></pre>