### PR TITLE
Update index.md - Added Gradle to the first lines of the home page to promote this build tool.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,27 @@ rightmenu: true
 
 ```
 
+### Install With [Gradle](https://mvnrepository.com/artifact/com.konghq/unirest-java)[:](https://repo.maven.apache.org/maven2/com/konghq/unirest-java/)
+```gradle
+// Make sure you added the mavencentral repository
+repositories {
+    mavenCentral()
+}
+
+// Pull in as a traditional dependency
+dependencies {
+    // ... Your other dependencies
+    implementation 'com.konghq:unirest-java:3.11.09'
+}
+
+// OR as a snazzy new standalone
+dependencies {
+    // ... Your other dependencies
+    implementation 'com.konghq:unirest-java:3.11.09:standalone'
+}
+```
+
+
 ### Upgrading from Previous Versions
 See the [Upgrade Guide](https://github.com/Kong/unirest-java/blob/master/UPGRADE_GUIDE.md)
 


### PR DESCRIPTION
I just added the Gradle way of adding Unirest as a dependency in the home page. Effectively, this build tool is very popular and maven not used that much nowadays.