### PR TITLE
Minor cleanup: make MockClient.defaultResponse not null

### DIFF
--- a/unirest-mocks/src/main/java/kong/unirest/Invocation.java
+++ b/unirest-mocks/src/main/java/kong/unirest/Invocation.java
@@ -55,11 +55,6 @@ class Invocation implements Expectation, ExpectedResponse {
         this.expected = true;
     }
 
-    public Invocation(Routes routes, HttpRequest request) {
-        this.routes = routes;
-        this.expectedHeaders = request.getHeaders();
-    }
-
     Invocation(Routes routes, Invocation other) {
         this.routes = routes;
         this.response = other.response;

--- a/unirest-mocks/src/main/java/kong/unirest/MockClient.java
+++ b/unirest-mocks/src/main/java/kong/unirest/MockClient.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
 public class MockClient implements Client, AsyncClient {
     private final Supplier<Config> config;
     private List<Routes> routes = new ArrayList<>();
-    private Invocation defaultResponse;
+    private Invocation defaultResponse = new Invocation();
 
     public MockClient(Supplier<Config> config){
         this.config = config;
@@ -87,7 +87,7 @@ public class MockClient implements Client, AsyncClient {
 
     @Override
     public <T> HttpResponse<T> request(HttpRequest request, Function<RawResponse, HttpResponse<T>> transformer) {
-        Routes exp = findExpecation(request);
+        Routes exp = findExpectation(request);
         Config c = this.config.get();
         c.getUniInterceptor().onRequest(request, c);
         MetricContext metric = c.getMetric().begin(request.toSummary());
@@ -98,7 +98,7 @@ public class MockClient implements Client, AsyncClient {
         return rez;
     }
 
-    private Routes findExpecation(HttpRequest request) {
+    private Routes findExpectation(HttpRequest request) {
         return routes.stream()
                 .filter(e -> e.matches(request))
                 .findFirst()
@@ -184,14 +184,12 @@ public class MockClient implements Client, AsyncClient {
      */
     public void reset() {
         routes.clear();
-        defaultResponse = null;
     }
 
     /**
      * return this status for any request that doesn't match a expectation
      */
     public ExpectedResponse defaultResponse() {
-        this.defaultResponse = new Invocation();
         return this.defaultResponse;
     }
 }

--- a/unirest-mocks/src/main/java/kong/unirest/Routes.java
+++ b/unirest-mocks/src/main/java/kong/unirest/Routes.java
@@ -37,11 +37,7 @@ class Routes implements Assert {
         Path p = new Path(request.getUrl());
         this.method = request.getHttpMethod();
         this.path = p.baseUrl();
-        if(expected != null){
-            invokes.add(new Invocation(this, expected));
-        } else {
-            invokes.add(new Invocation(this, request));
-        }
+        invokes.add(new Invocation(this, expected));
     }
 
     public Routes(HttpMethod method, Path p) {


### PR DESCRIPTION
I've identified that MockClient.defaultResponse can always be set to `new Invocation()`, avoiding potential NullPointerExceptions.