### PR TITLE
Ability to replace a map of headers Fixes #419

### DIFF
--- a/unirest/src/main/java/kong/unirest/BaseRequest.java
+++ b/unirest/src/main/java/kong/unirest/BaseRequest.java
@@ -112,6 +112,12 @@ abstract class BaseRequest<R extends HttpRequest> implements HttpRequest<R> {
     }
 
     @Override
+    public R headersReplace(Map<String, String> headerMap) {
+        this.headers.replace(headerMap);
+        return (R) this;
+    }
+
+    @Override
     public R responseEncoding(String encoding) {
         this.responseEncoding = encoding;
         return (R) this;

--- a/unirest/src/main/java/kong/unirest/Config.java
+++ b/unirest/src/main/java/kong/unirest/Config.java
@@ -651,6 +651,7 @@ public class Config {
      * Default is false
      *
      * @param value a bool is its true or not.
+     * @param maxRetryAttempts max retry attempts
      * @return this config object
      */
     public Config retryAfter(boolean value, int maxRetryAttempts) {

--- a/unirest/src/main/java/kong/unirest/Headers.java
+++ b/unirest/src/main/java/kong/unirest/Headers.java
@@ -203,6 +203,16 @@ public class Headers {
         }
     }
 
+    /**
+     * Replace all headers from a given map.
+     * @param headerMap the map of headers
+     */
+    public void replace(Map<String, String> headerMap) {
+        if (headerMap != null) {
+            headerMap.forEach(this::replace);
+        }
+    }
+
     static class Entry implements Header {
 
         private final String name;

--- a/unirest/src/main/java/kong/unirest/HttpRequest.java
+++ b/unirest/src/main/java/kong/unirest/HttpRequest.java
@@ -111,6 +111,13 @@ public interface HttpRequest<R extends HttpRequest>  {
     R headers(Map<String, String> headerMap);
 
     /**
+     * Replace headers as a map
+     * @param headerMap a map of headers
+     * @return this request builder
+     */
+    R headersReplace(Map<String, String> headerMap);
+
+    /**
      * Add a simple cookie header
      * @param name the name of the cookie
      * @param value the value of the cookie

--- a/unirest/src/test/java/BehaviorTests/HeaderTest.java
+++ b/unirest/src/test/java/BehaviorTests/HeaderTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static BehaviorTests.TestUtils.mapOf;
@@ -345,5 +346,17 @@ class HeaderTest extends BddTest {
                 .asObject(RequestCapture.class)
                 .getBody()
                 .assertHeader("foo","bar");
+    }
+
+    @Test
+    void replaceHeadersTests() {
+        Unirest.config().addDefaultHeader("foo", "default");
+        Unirest.get(MockServer.GET)
+                .header("foo","bar")
+                .headersReplace(mapOf("foo", "replace", "two", "bar"))
+                .asObject(RequestCapture.class)
+                .getBody()
+                .assertHeader("foo","replace")
+                .assertHeader("two","bar");
     }
 }


### PR DESCRIPTION
This is just adding another method to replace all headers given in a map.