### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.14.0-rc1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.14.0-rc1</jackson.version>
         <main.dir>${project.basedir}</main.dir>
         <junit.version>5.8.2</junit.version>
         <mockito.version>4.3.1</mockito.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.13.3
- [CVE-2022-42004](https://www.oscs1024.com/hd/CVE-2022-42004)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.13.3 to 2.14.0-rc1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS