### PR TITLE
feat(Path): optimize param method

### DIFF
--- a/unirest/src/main/java/kong/unirest/core/Path.java
+++ b/unirest/src/main/java/kong/unirest/core/Path.java
@@ -58,14 +58,10 @@ class Path {
 
     public void param(String name, String value) {
         Matcher matcher = Pattern.compile("\\{" + name + "\\}").matcher(url);
-        int count = 0;
-        while (matcher.find()) {
-            count++;
-        }
-        if (count == 0) {
+        if (!matcher.find()) {
             throw new UnirestException("Can't find route parameter name \"" + name + "\"");
         }
-        this.url = url.replaceAll("\\{" + name + "\\}", encodePath(value));
+        this.url = matcher.replaceAll(encodePath(value));
     }
 
     private String encodePath(String value) {


### PR DESCRIPTION
Hi, I've been exploring unirest-java and appreciate the work you've put into this project. I noticed a small area in the param method where we might reduce the complexity slightly by directly replacing the parameter without pre-counting its occurrences.

This proposed change employs `Matcher.find()` to ensure the placeholder exists, followed by `Matcher.replaceAll()` to perform the substitution. It's a subtle tweak that I hope aligns with the project's coding practices.

Thank you for maintaining such a valuable resource for the community.