### PR TITLE
Don't sort MultipartBody fields by default

### DIFF
--- a/unirest-bdd-tests/src/test/java/BehaviorTests/BodyLogSummaryTest.java
+++ b/unirest-bdd-tests/src/test/java/BehaviorTests/BodyLogSummaryTest.java
@@ -112,6 +112,24 @@ class BodyLogSummaryTest extends BddTest {
         assertEquals("POST http://somewhere/beans?fruit=apple\n" +
                 "Accept: image/raw\n" +
                 "===================================\n" +
+                "band=Talking+Heads&album=77", log);
+    }
+
+    @Test
+    void simpleFormBodySorted() {
+        var log = Unirest.post("http://somewhere/{magic}")
+                .routeParam("magic", "beans")
+                .queryString("fruit", "apple")
+                .header("Accept", "image/raw")
+                .field("band", "Talking Heads")
+                .field("album", "77")
+                .sortFields()
+                .toSummary()
+                .asString();
+
+        assertEquals("POST http://somewhere/beans?fruit=apple\n" +
+                "Accept: image/raw\n" +
+                "===================================\n" +
                 "album=77&band=Talking+Heads", log);
     }
 
@@ -123,6 +141,42 @@ class BodyLogSummaryTest extends BddTest {
                 .field("band", "Talking Heads")
                 .field("album", "77")
                 .field("file", rezFile("/test.txt"))
+                .boundary(boundary)
+                .toSummary()
+                .asString();
+
+        assertThat(body).isEqualTo(
+                "POST http://localhost:4567/raw\n" +
+                        "Accept: image/raw\n" +
+                        "Content-Type: multipart/form-data; boundary=ABC-123-BOUNDARY;charset=UTF-8\"\n" +
+                        "===================================\n" +
+                        "--ABC-123-BOUNDARY\n" +
+                        "Content-Disposition: form-data; name:\"band\"\n" +
+                        "Content-Type: application/x-www-form-urlencoded; charset=UTF-8\n" +
+                        "Talking Heads\n" +
+                        "\n" +
+                        "--ABC-123-BOUNDARY\n" +
+                        "Content-Disposition: form-data; name:\"album\"\n" +
+                        "Content-Type: application/x-www-form-urlencoded; charset=UTF-8\n" +
+                        "77\n" +
+                        "\n" +
+                        "--ABC-123-BOUNDARY\n" +
+                        "Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\n" +
+                        "Content-Type: application/octet-stream\n" +
+                        "<BINARY DATA>\n"
+        );
+
+    }
+
+    @Test
+    void multiPartSorted() {
+        var boundary = "ABC-123-BOUNDARY";
+        var body = Unirest.post(MockServer.ECHO_RAW)
+                .header("Accept", "image/raw")
+                .field("band", "Talking Heads")
+                .field("album", "77")
+                .field("file", rezFile("/test.txt"))
+                .sortFields()
                 .boundary(boundary)
                 .toSummary()
                 .asString();
@@ -149,6 +203,5 @@ class BodyLogSummaryTest extends BddTest {
         );
 
     }
-
 
 }

--- a/unirest-bdd-tests/src/test/java/BehaviorTests/MultiPartFormPostingTest.java
+++ b/unirest-bdd-tests/src/test/java/BehaviorTests/MultiPartFormPostingTest.java
@@ -424,6 +424,24 @@ class MultiPartFormPostingTest extends BddTest {
     }
 
     @Test
+    void rawInspectionSorted() {
+        var body = Unirest.post(MockServer.ECHO_RAW)
+                .field("marky", "mark")
+                .field("funky", "bunch")
+                .field("file", rezFile("/test.txt"))
+                .sortFields()
+                .asString()
+                .getBody();
+
+        var expected = TestUtil.getResource("rawPostSorted.txt").replaceAll("\r", "").trim();
+
+        var id = body.substring(2, body.indexOf("\n") - 1);
+        body = body.replaceAll(id, "IDENTIFIER").replaceAll("\r", "").trim();
+
+        assertEquals(expected, body);
+    }
+
+    @Test
     void mediaTypesForParts() {
         Unirest.post(MockServer.POST)
                 .field("content", rezInput("/spidey.pdf"), APPLICATION_PDF, "spiderman")

--- a/unirest-bdd-tests/src/test/resources/rawPost.txt
+++ b/unirest-bdd-tests/src/test/resources/rawPost.txt
@@ -1,16 +1,16 @@
 --IDENTIFIER
-Content-Disposition: form-data; name="file"; filename="test.txt"
-Content-Type: application/octet-stream
+Content-Disposition: form-data; name="marky"
+Content-Type: application/x-www-form-urlencoded; charset=UTF-8
 
-This is a test file
+mark
 --IDENTIFIER
 Content-Disposition: form-data; name="funky"
 Content-Type: application/x-www-form-urlencoded; charset=UTF-8
 
 bunch
 --IDENTIFIER
-Content-Disposition: form-data; name="marky"
-Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+Content-Disposition: form-data; name="file"; filename="test.txt"
+Content-Type: application/octet-stream
 
-mark
+This is a test file
 --IDENTIFIER--

--- a/unirest-bdd-tests/src/test/resources/rawPostSorted.txt
+++ b/unirest-bdd-tests/src/test/resources/rawPostSorted.txt
@@ -1,0 +1,16 @@
+--IDENTIFIER
+Content-Disposition: form-data; name="file"; filename="test.txt"
+Content-Type: application/octet-stream
+
+This is a test file
+--IDENTIFIER
+Content-Disposition: form-data; name="funky"
+Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+
+bunch
+--IDENTIFIER
+Content-Disposition: form-data; name="marky"
+Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+
+mark
+--IDENTIFIER--

--- a/unirest/src/main/java/kong/unirest/core/HttpRequestMultiPart.java
+++ b/unirest/src/main/java/kong/unirest/core/HttpRequestMultiPart.java
@@ -123,6 +123,12 @@ class HttpRequestMultiPart extends BaseRequest<MultipartBody> implements Multipa
     }
 
     @Override
+    public MultipartBody sortFields() {
+        Collections.sort(parameters);
+        return this;
+    }
+
+    @Override
     public MultipartBody charset(Charset charset) {
         this.charSet = charset;
         return this;
@@ -195,7 +201,6 @@ class HttpRequestMultiPart extends BaseRequest<MultipartBody> implements Multipa
 
     private void addPart(BodyPart value) {
         parameters.add(value);
-        Collections.sort(parameters);
     }
 
     @Override

--- a/unirest/src/main/java/kong/unirest/core/MultipartBody.java
+++ b/unirest/src/main/java/kong/unirest/core/MultipartBody.java
@@ -133,6 +133,12 @@ public interface MultipartBody extends HttpRequest<MultipartBody>, Body {
     MultipartBody field(String name, byte[] bytes, String fileName);
 
     /**
+     * sort fields on name, in alphabetical order
+     * @return The same MultipartBody
+     */
+    MultipartBody sortFields();
+
+    /**
      * Set the encoding of the request body
      * @param charset the character set encoding of the body
      * @return The same MultipartBody


### PR DESCRIPTION
Some web services rely on the original entry list order, and sorting of the entry list furthermore makes it impossible to emulate web browsers.

Alphabetical sorting of multipart/form-data fields directly contradicts RFC 7578, which states:

5.2.  Ordered Fields and Duplicated Field Names

   Form processors given forms with a well-defined ordering SHOULD send
   back results in order.  (Note that there are some forms that do not
   define a natural order.)  Intermediaries MUST NOT reorder the
   results.  Form parts with identical field names MUST NOT be
   coalesced.

This commit removes the default sorting of MultipartBody fields.

To achieve alphabetical sorting of fields, there are two simple options:

* Call field() following the alphabetical order of fields names.
* Call fields() with a TreeMap parameter (LinkedHashMap for entry order).

In case someone should rely on functionality to sort fields after having them added, the function sortFields() is also provided.