### PR TITLE
Fix GitHub Actions JDK setup label

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'


### PR DESCRIPTION
## Summary

Updates the GitHub Actions setup step label from `Set up JDK 1.11` to `Set up JDK 21`.

## Motivation

The workflow already uses `java-version: '21'`, but the step name still says JDK 1.11. This can confuse contributors when setting up the project locally, especially because the test runtime uses newer dependencies.

## Changes

- Renamed the GitHub Actions Java setup step to match the configured JDK version.
- No build, dependency, or Java compatibility changes.

## Testing

Configuration-only change. Existing workflow still uses JDK 21.