### PR TITLE
Support chained expectations in MockClient

### DIFF
--- a/unirest-modules-mocks/src/main/java/kong/unirest/core/Routes.java
+++ b/unirest-modules-mocks/src/main/java/kong/unirest/core/Routes.java
@@ -93,20 +93,38 @@ class Routes implements Assert {
     }
 
     private Optional<Invocation> getBestMatch(HttpRequest request, boolean expected) {
-        Map<Integer, Invocation> map = new TreeMap<>();
-        invokes.stream()
-                .forEach(i -> {
-                    Integer score = i.scoreMatch(request);
-                    if(score >= 0) {
-                        map.put(score, i);
-                    }
-                });
-        if (map.size() == 0) {
+        Invocation best = null;
+        int bestScore = -1;
+
+        for (Invocation invocation : invokes) {
+            if (!invocation.isExpected().equals(expected)) {
+                continue;
+            }
+
+            int score = invocation.scoreMatch(request);
+
+            if (score < 0) {
+                continue;
+            }
+
+            if (score > bestScore) {
+                best = invocation;
+                bestScore = score;
+            } else if (score == bestScore
+                    && expected
+                    && best != null
+                    && best.requestSize() > 0
+                    && invocation.requestSize() == 0) {
+                best = invocation;
+            }
+        }
+
+        if (best == null) {
             return Optional.empty();
         }
-        Invocation value = map.get(Collections.max(map.keySet()));
-        value.log(request);
-        return Optional.of(value);
+
+        best.log(request);
+        return Optional.of(best);
     }
 
     @Override

--- a/unirest-modules-mocks/src/test/java/kong/tests/MultipleExpectsTest.java
+++ b/unirest-modules-mocks/src/test/java/kong/tests/MultipleExpectsTest.java
@@ -94,7 +94,7 @@ class MultipleExpectsTest extends Base {
     }
 
     @Test
-    void whenDuplicateExpectsExistUseTheLastOne() {
+    void whenDuplicateExpectsExistUseThemInOrder() {
         client.expect(GET, path)
                 .queryString("monster", "grover")
                 .thenReturn("one");
@@ -103,17 +103,19 @@ class MultipleExpectsTest extends Base {
                 .queryString("monster", "grover")
                 .thenReturn("two");
 
-        String result = Unirest.get(path)
+        String first = Unirest.get(path)
                 .queryString("monster", "grover")
                 .asString()
                 .getBody();
 
-        assertEquals("two", result);
+        String second = Unirest.get(path)
+                .queryString("monster", "grover")
+                .asString()
+                .getBody();
 
-        assertException(() -> client.verifyAll(),
-                "Expected at least 1 invocations but got 0\n" +
-                        "GET http://basic\n" +
-                        "Params:\n" +
-                        "monster: grover");
+        assertEquals("one", first);
+        assertEquals("two", second);
+
+        client.verifyAll();
     }
 }


### PR DESCRIPTION
## Summary

Adds support for chained `MockClient` expectations when multiple expectations are registered for the same request.

## Motivation

Previously, duplicate expectations for the same method/path could result in the later expectation overriding the earlier one. This made it difficult to model ordered responses for repeated calls to the same endpoint.

Fixes #531.

## Changes

- Updated mock request matching to keep equal-score expectations in registration order.
- Updated the duplicate expectation test to verify ordered response consumption.
- Preserved existing verification behavior for consumed expectations.

## Testing

```bash
mvn -pl unirest-modules-mocks test