### PR TITLE
Fix never-invoked expectation assertion message

### DIFF
--- a/unirest-modules-mocks/src/main/java/kong/unirest/core/ExpectedResponseRecord.java
+++ b/unirest-modules-mocks/src/main/java/kong/unirest/core/ExpectedResponseRecord.java
@@ -91,7 +91,7 @@ class ExpectedResponseRecord implements ExpectedResponse, ResponseBuilder {
     @Override
     public void verify(Times times) {
         if(expectation == null){
-            throw new UnirestAssertion("A expectation was never invoked!");
+            throw new UnirestAssertion("An expectation was never invoked!");
         }
         expectation.verify(times);
     }

--- a/unirest-modules-mocks/src/test/java/kong/tests/VerifyTimesTest.java
+++ b/unirest-modules-mocks/src/test/java/kong/tests/VerifyTimesTest.java
@@ -66,7 +66,8 @@ public class VerifyTimesTest extends Base {
         client.expect(HttpMethod.POST, path)
                 .thenReturn(r -> response);
 
-        assertThrows(UnirestAssertion.class, response::verify);
+        var ex = assertThrows(UnirestAssertion.class, response::verify);
+        assertEquals("An expectation was never invoked!", ex.getMessage());
 
         Unirest.post(path).asEmpty();
 


### PR DESCRIPTION
## Summary

Fixes the grammar in the assertion message used when an expected response is verified before it has been invoked.

## Changes

- Changed `A expectation was never invoked!` to `An expectation was never invoked!`.
- Added assertion coverage for the exception message in `VerifyTimesTest`.

## Testing

```bash
mvn -pl unirest-modules-mocks -am test