### PR TITLE
Fix configuration docs example

### DIFF
--- a/mkdocs/docs/configuration.md
+++ b/mkdocs/docs/configuration.md
@@ -5,12 +5,12 @@ All configuration is now done through ```Unirest.config()```
 
 ```java
     Unirest.config()
-           .connectTimeout(1000)
-           .proxy(new Proxy("https://proxy"))
-           .setDefaultHeader("Accept", "application/json")
-           .followRedirects(false)
-           .enableCookieManagement(false)
-           .addInterceptor(new MyCustomInterceptor());
+            .connectTimeout(1000)
+            .proxy("proxy.example.com", 8080)
+            .setDefaultHeader("Accept", "application/json")
+            .followRedirects(false)
+            .enableCookieManagement(false)
+            .interceptor(new MyCustomInterceptor());
 ```
 
 Changing Unirest's config should ideally be done once, or rarely. Once Unirest has been activated configuration options that are involved in creating the client cannot be changed without an explicit shutdown or reset.


### PR DESCRIPTION
## Summary

Fixes the first configuration example so it matches the current `Config` API.

## Changes

- Replaced `addInterceptor(...)` with `interceptor(...)`.
- Replaced the unsupported single-argument `Proxy` constructor example with `proxy(String, int)`.

## Testing

Docs-only change.