### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,9 @@ on:
       - apache5
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     timeout-minutes: 15


### PR DESCRIPTION
Potential fix for [https://github.com/Kong/unirest-java/security/code-scanning/9](https://github.com/Kong/unirest-java/security/code-scanning/9)

To fix this, add an explicit `permissions` block so the workflow does not inherit potentially broad defaults. The best, minimal, non-breaking fix here is to set workflow-level permissions to read-only for contents, which satisfies checkout/build needs and applies to all jobs unless overridden.

In `.github/workflows/maven.yml`, insert:

```yml
permissions:
  contents: read
```

near the top level (for example, after the `on:` block and before `jobs:`). This preserves existing functionality while documenting and enforcing least privilege. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
