### PR TITLE
Fix Jackson integer error message

### DIFF
--- a/unirest-modules-jackson-legacy/src/main/java/kong/unirest/modules/jackson2/JacksonElement.java
+++ b/unirest-modules-jackson-legacy/src/main/java/kong/unirest/modules/jackson2/JacksonElement.java
@@ -128,7 +128,7 @@ class JacksonElement<T extends JsonNode> implements JsonEngine.Element {
     @Override
     public BigInteger getAsBigInteger() {
         if(!element.isIntegralNumber()) {
-            throw new NumberFormatException("Not a integer");
+            throw new NumberFormatException("Not an integer");
         }
         return element.bigIntegerValue();
     }

--- a/unirest-modules-jackson/src/main/java/kong/unirest/modules/jackson/JacksonElement.java
+++ b/unirest-modules-jackson/src/main/java/kong/unirest/modules/jackson/JacksonElement.java
@@ -128,7 +128,7 @@ class JacksonElement<T extends JsonNode> implements JsonEngine.Element {
     @Override
     public BigInteger getAsBigInteger() {
         if(!element.isIntegralNumber()) {
-            throw new NumberFormatException("Not a integer");
+            throw new NumberFormatException("Not an integer");
         }
         return element.bigIntegerValue();
     }


### PR DESCRIPTION
## Summary

Fixes a grammar typo in the Jackson JSON element error message.

## Changes

- Changed `Not a integer` to `Not an integer` in the Jackson module.
- Applied the same fix to the Jackson legacy module.

## Testing

```bash
mvn -pl unirest-modules-jackson,unirest-modules-jackson-legacy -am test